### PR TITLE
fix: rename ScrollingBackground component

### DIFF
--- a/src/components/ui/ScrollingBackground.tsx
+++ b/src/components/ui/ScrollingBackground.tsx
@@ -1,8 +1,8 @@
-// src/components/ui/SteppingBackground
+// src/components/ui/ScrollingBackground
 
 import React from 'react';
 
-const SteppingBackground: React.FC = () => {
+const ScrollingBackground: React.FC = () => {
   // Static text for each line
   const baseText = `E2039DE1847774F7953A36A20DE1C56B0F E03A1F E38A1F E2991F E37A0F E47A0F D46C0F D46C0F D3892E F DD1F65966A1E E1A83E F1A73E F1A83E`;
 
@@ -42,4 +42,4 @@ const SteppingBackground: React.FC = () => {
   );
 };
 
-export default SteppingBackground;
+export default ScrollingBackground;


### PR DESCRIPTION
## Summary
- update intro comment to match file name
- rename `SteppingBackground` to `ScrollingBackground`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af7052aa88322a7fde89c90c19633