### PR TITLE
refactor: use requestAnimationFrame for code text animation

### DIFF
--- a/src/components/visuals/CodeText.tsx
+++ b/src/components/visuals/CodeText.tsx
@@ -23,8 +23,15 @@ export default function CodeText() {
     if (!isDesktop()) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     setEnabled(true);
-    const interval = setInterval(() => setTick((t) => t + 1), 16);
-    return () => clearInterval(interval);
+
+    let frameId: number;
+    const tick = () => {
+      setTick((t) => t + 1);
+      frameId = requestAnimationFrame(tick);
+    };
+
+    frameId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frameId);
   }, []);
 
   if (!enabled) return null;


### PR DESCRIPTION
## Summary
- replace `setInterval` with `requestAnimationFrame` in `CodeText` for smoother updates

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d2822c3788322b2b9ba615386d14a