### PR TITLE
feat: add skip link to main content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ const CodeText = React.lazy(() => import('@/components/visuals/CodeText'));
 function AppContent() {
   return (
     <>
+      <a href="#main" className="sr-only focus:block">
+        Skip to main content
+      </a>
       <Header />
 
       <main id="main" className="m-[0_auto] max-w-4xl px-6 sm:px-4">


### PR DESCRIPTION
## Summary
- add accessible skip link before header to jump to main content

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d281b52d48322afcd1920aa96f38c