### PR TITLE
fix: add passive options to mouse coords hook

### DIFF
--- a/src/hooks/useMouseCoords.ts
+++ b/src/hooks/useMouseCoords.ts
@@ -15,12 +15,14 @@ export default function useMouseCoords() {
       }
     };
 
-    window.addEventListener('mousemove', update);
-    window.addEventListener('touchmove', update);
+    const options: AddEventListenerOptions = { passive: true };
+
+    window.addEventListener('touchmove', update as (e: TouchEvent) => void, options);
+    window.addEventListener('mousemove', update as (e: MouseEvent) => void, options);
 
     return () => {
-      window.removeEventListener('mousemove', update);
-      window.removeEventListener('touchmove', update);
+      window.removeEventListener('touchmove', update as (e: TouchEvent) => void, options);
+      window.removeEventListener('mousemove', update as (e: MouseEvent) => void, options);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- add passive true to touch and mouse move event listeners
- ensure cleanup listeners use the same options

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run vercel:build` *(fails: npm error code E403 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d282787f48322a0101f0939f19d49