### PR TITLE
fix: center layout sections with mx-auto

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ function AppContent() {
     <>
       <Header />
 
-      <main id="main" className="m-[0_auto] max-w-4xl px-6 sm:px-4">
+      <main id="main" className="mx-auto max-w-4xl px-6 sm:px-4">
         <Hero />
         <Projects />
       </main>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 export default function Footer() {
   return (
-    <footer id="footer" className="m-[0_auto] max-w-4xl px-6 pt-8 text-sm sm:px-4">
+    <footer id="footer" className="mx-auto max-w-4xl px-6 pt-8 text-sm sm:px-4">
       <div className="flex items-center justify-between py-4 text-sm">
         <p>
           From{' '}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
       id="header"
       className="background-color/75 sticky top-0 z-10 py-2 backdrop-blur-xl sm:py-3"
     >
-      <nav className="m-[0_auto] flex max-w-4xl items-center justify-between px-6 font-semibold sm:px-4">
+      <nav className="mx-auto flex max-w-4xl items-center justify-between px-6 font-semibold sm:px-4">
         <a
           className="grid grid-flow-col items-center overflow-hidden rounded-full"
           href="/"


### PR DESCRIPTION
## Summary
- replace `m-[0_auto]` with `mx-auto` to center header, main, and footer sections

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d280d28608322800f5259f9093ec7