### PR TITLE
fix: correct header background class

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
   return (
     <header
       id="header"
-      className="background-color/75 sticky top-0 z-10 py-2 backdrop-blur-xl sm:py-3"
+      className="sticky top-0 z-10 bg-white/75 py-2 backdrop-blur-xl dark:bg-gray-900/75 sm:py-3"
     >
       <nav className="m-[0_auto] flex max-w-4xl items-center justify-between px-6 font-semibold sm:px-4">
         <a


### PR DESCRIPTION
## Summary
- replace invalid `background-color/75` with `bg-white/75 dark:bg-gray-900/75`

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- `npm run vercel:build` *(fails: 403 Forbidden retrieving vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_689d280b7c3c8322a45cbcd62498efc6