### PR TITLE
chore: bump TypeScript to 4.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^3.4.1",
-        "typescript": "^4.8.0",
+        "typescript": "^4.9.5",
         "vite": "^6.3.5",
         "vitest": "^3.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^3.4.1",
-    "typescript": "^4.8.0",
+    "typescript": "^4.9.5",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
## Summary
- bump TypeScript to 4.9.5 to match available tooling

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d284827788322b78935bdd4c9dc66