### PR TITLE
fix: guard browser-only event listeners

### DIFF
--- a/src/hooks/useMouseCoords.ts
+++ b/src/hooks/useMouseCoords.ts
@@ -6,6 +6,8 @@ export default function useMouseCoords() {
   const coords = useRef({ x: 0, y: 0 });
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+
     const update = (e: MouseEvent | TouchEvent) => {
       if ('touches' in e) {
         const touch = e.touches[0];


### PR DESCRIPTION
## Summary
- prevent useMouseCoords from accessing `window` during SSR

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d3632415c83228bcff20667482a0d