### PR TITLE
Remove lucide-react declaration from global types

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,1 @@
-declare module 'lucide-react';
 declare module '*.webp';


### PR DESCRIPTION
## Summary
- remove redundant `lucide-react` module declaration from global type definitions

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run vercel:build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d3620f8d48322aa319b673c82a193