### PR TITLE
Add dark mode and theme toggle tests

### DIFF
--- a/src/hooks/useDarkMode.test.ts
+++ b/src/hooks/useDarkMode.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import useDarkMode from './useDarkMode';
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
+  });
+
+  it('initializes from localStorage when available', () => {
+    window.localStorage.setItem('darkMode', 'true');
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current[0]).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+
+  it('uses provided initial value when no stored preference', () => {
+    const { result } = renderHook(() => useDarkMode(false));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('toggles dark class on html and body and updates localStorage', () => {
+    const { result } = renderHook(() => useDarkMode(false));
+    const [, setDarkMode] = result.current;
+
+    act(() => setDarkMode(true));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
+    expect(window.localStorage.getItem('darkMode')).toBe('true');
+
+    act(() => setDarkMode(false));
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.body.classList.contains('dark')).toBe(false);
+    expect(window.localStorage.getItem('darkMode')).toBe('false');
+  });
+});

--- a/src/utils/themeToggle.test.ts
+++ b/src/utils/themeToggle.test.ts
@@ -1,0 +1,40 @@
+import { vi } from 'vitest';
+import themeToggle from './themeToggle';
+
+describe('themeToggle', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('toggles dark mode', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const setDarkMode = vi.fn();
+
+    themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
+
+    expect(setDarkMode).toHaveBeenCalledWith(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('cleans up previous overlay on subsequent calls', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const setDarkMode = vi.fn();
+
+    themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
+    const overlay = document.body.lastElementChild as HTMLElement;
+    expect(overlay).toBeTruthy();
+
+    themeToggle({ button, darkMode: true, setDarkMode, shouldReduceMotion: true });
+    expect(overlay.isConnected).toBe(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test dark mode hook initialization and DOM class toggling
- test themeToggle utility for dark mode toggling and cleanup

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d38afb5fc8322b029d10fcc1c3882