### PR TITLE
test: restore window width in isDesktop test

### DIFF
--- a/src/utils/isDesktop.test.ts
+++ b/src/utils/isDesktop.test.ts
@@ -1,6 +1,19 @@
 import isDesktop from './isDesktop';
 
 describe('isDesktop', () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      value: originalInnerWidth,
+    });
+  });
+
   it('returns true when width is at least 768px', () => {
     Object.defineProperty(window, 'innerWidth', { writable: true, value: 800 });
     expect(isDesktop()).toBe(true);


### PR DESCRIPTION
## Summary
- preserve original window width between isDesktop tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d3b64c96483229b70408624e49909