### PR TITLE
refactor: simplify motion provider

### DIFF
--- a/src/context/MotionContext.tsx
+++ b/src/context/MotionContext.tsx
@@ -1,7 +1,9 @@
 // src/context/MotionContext.tsx
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { AnimatePresence } from 'framer-motion';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { AnimatePresence as MotionAnimatePresence } from 'framer-motion';
+
+const AnimatePresence = MotionAnimatePresence as React.FC<{ children: ReactNode }>;
 
 interface MotionContextValue {
   shouldReduceMotion: boolean;
@@ -9,9 +11,7 @@ interface MotionContextValue {
 
 const MotionContext = createContext<MotionContextValue | undefined>(undefined);
 
-const TypedAnimatePresence = AnimatePresence as React.FC<{ children: React.ReactNode }>;
-
-export function MotionProvider({ children }: { children: React.ReactNode }) {
+export function MotionProvider({ children }: { children: ReactNode }) {
   const [shouldReduceMotion, setShouldReduceMotion] = useState(false);
 
   useEffect(() => {
@@ -24,7 +24,7 @@ export function MotionProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <MotionContext.Provider value={{ shouldReduceMotion }}>
-      <TypedAnimatePresence>{children}</TypedAnimatePresence>
+      <AnimatePresence>{children}</AnimatePresence>
     </MotionContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- remove TypedAnimatePresence wrapper and render AnimatePresence directly
- type MotionProvider children as ReactNode

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d405a67f48322a994da0fa5422e3f