### PR TITLE
fix: optimize cursor mask rendering

### DIFF
--- a/src/components/visuals/CodeText.tsx
+++ b/src/components/visuals/CodeText.tsx
@@ -15,30 +15,19 @@ const aqua = 'text-[#4ec9b0]'; // types/objects
 const pink = 'text-[#c586c0]'; // control flow / returns
 
 export default function CodeText() {
-  const coords = useMouseCoords();
-  const [, setTick] = useState(0);
   const [enabled, setEnabled] = useState(false);
+  useMouseCoords(enabled);
 
   useEffect(() => {
     if (!isDesktop()) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     setEnabled(true);
-
-    let frameId: number;
-    const tick = () => {
-      setTick((t) => t + 1);
-      frameId = requestAnimationFrame(tick);
-    };
-
-    frameId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frameId);
   }, []);
 
   if (!enabled) return null;
 
-  const x = coords.current.x + window.scrollX;
-  const y = coords.current.y + window.scrollY;
-  const mask = `radial-gradient(160px at ${x}px ${y}px, rgba(0, 0, 0, 1) 20%, rgba(0, 0, 0, 0) 60%)`;
+  const mask =
+    'radial-gradient(160px at var(--cursor-x) var(--cursor-y), rgba(0, 0, 0, 1) 20%, rgba(0, 0, 0, 0) 60%)';
 
   return (
     <div

--- a/src/hooks/useMouseCoords.ts
+++ b/src/hooks/useMouseCoords.ts
@@ -1,32 +1,46 @@
 // src/hooks/useMouseCoords.ts
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
-export default function useMouseCoords() {
-  const coords = useRef({ x: 0, y: 0 });
+export default function useMouseCoords(active = true) {
+  const [coords, setCoords] = useState({ x: 0, y: 0 });
 
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (!active || typeof window === 'undefined') return;
 
     const update = (e: MouseEvent | TouchEvent) => {
+      let x: number;
+      let y: number;
+
       if ('touches' in e) {
         const touch = e.touches[0];
-        if (touch) coords.current = { x: touch.clientX, y: touch.clientY };
+        if (!touch) return;
+        x = touch.clientX + window.scrollX;
+        y = touch.clientY + window.scrollY;
       } else {
-        coords.current = { x: e.clientX, y: e.clientY };
+        const mouse = e as MouseEvent;
+        x = mouse.clientX + window.scrollX;
+        y = mouse.clientY + window.scrollY;
       }
+
+      setCoords({ x, y });
+
+      // Update CSS variables so components can react to cursor position
+      const root = document.documentElement;
+      root.style.setProperty('--cursor-x', `${x}px`);
+      root.style.setProperty('--cursor-y', `${y}px`);
     };
 
     const options: AddEventListenerOptions = { passive: true };
 
-    window.addEventListener('touchmove', update as (e: TouchEvent) => void, options);
-    window.addEventListener('mousemove', update as (e: MouseEvent) => void, options);
+    window.addEventListener('touchmove', update as EventListener, options);
+    window.addEventListener('mousemove', update as EventListener, options);
 
     return () => {
-      window.removeEventListener('touchmove', update as (e: TouchEvent) => void, options);
-      window.removeEventListener('mousemove', update as (e: MouseEvent) => void, options);
+      window.removeEventListener('touchmove', update as EventListener, options);
+      window.removeEventListener('mousemove', update as EventListener, options);
     };
-  }, []);
+  }, [active]);
 
   return coords;
 }


### PR DESCRIPTION
## Summary
- remove requestAnimationFrame loop from CodeText
- update mouse coordinates hook to sync CSS variables
- compute radial mask using CSS custom properties

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run vercel:build` *(fails: 403 Forbidden retrieving vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_689d40293f7483229dede2e0e29a1726