### PR TITLE
feat: sync with system dark mode

### DIFF
--- a/src/hooks/useDarkMode.test.ts
+++ b/src/hooks/useDarkMode.test.ts
@@ -1,11 +1,38 @@
 import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
 import useDarkMode from './useDarkMode';
 
+interface MutableMediaQueryList extends MediaQueryList {
+  matches: boolean;
+}
+
 describe('useDarkMode', () => {
+  let mql: MutableMediaQueryList;
+  let listener: ((e: MediaQueryListEvent) => void) | null;
+
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.classList.remove('dark');
     document.body.classList.remove('dark');
+
+    listener = null;
+    mql = {
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((_, cb) => {
+        listener = cb;
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn((e: MediaQueryListEvent) => {
+        listener?.(e);
+        return true;
+      }),
+    } as MutableMediaQueryList;
+
+    window.matchMedia = vi.fn().mockReturnValue(mql);
   });
 
   it('initializes from localStorage when available', () => {
@@ -34,5 +61,17 @@ describe('useDarkMode', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false);
     expect(document.body.classList.contains('dark')).toBe(false);
     expect(window.localStorage.getItem('darkMode')).toBe('false');
+  });
+
+  it('reacts to system color scheme changes', () => {
+    const { result } = renderHook(() => useDarkMode());
+    expect(result.current[0]).toBe(false);
+
+    act(() => {
+      mql.matches = true;
+      listener?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current[0]).toBe(true);
   });
 });

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -29,6 +29,12 @@ export default function useDarkMode(initial?: boolean): [boolean, (value: boolea
   useEffect(() => {
     if (!isBrowser) return;
 
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setDarkModeState(event.matches);
+    };
+    mediaQuery.addEventListener('change', handleChange);
+
     const html = document.documentElement;
     const body = document.body;
 
@@ -41,6 +47,10 @@ export default function useDarkMode(initial?: boolean): [boolean, (value: boolea
     }
 
     window.localStorage.setItem('darkMode', String(darkMode));
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
   }, [darkMode, isBrowser]);
 
   const setDarkMode = (value: boolean) => {


### PR DESCRIPTION
## Summary
- watch for `prefers-color-scheme` changes and update dark mode state
- test dark mode hook against system preference changes

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden when fetching vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d4018e6e48322b20591c998a70066