### PR TITLE
Handle missing project links in ProjectCard

### DIFF
--- a/src/components/ProjectCard.test.tsx
+++ b/src/components/ProjectCard.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import ProjectCard from './ProjectCard';
+
+describe('ProjectCard', () => {
+  it('renders a link when siteLink exists', () => {
+    render(<ProjectCard />);
+    const link = screen.getByRole('link', {
+      name: /Turistar travel planner/i,
+    });
+    expect(link.getAttribute('href')).toBe('https://travel-planner-orpin.vercel.app/');
+  });
+
+  it('renders a disabled container when siteLink is missing', () => {
+    render(<ProjectCard />);
+    const title = screen.getByText('Personal Portfolio');
+    expect(title.closest('a')).toBeNull();
+    const container = title.closest('div[aria-disabled="true"]');
+    expect(container).not.toBeNull();
+    expect(container?.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -7,47 +7,61 @@ export default function ProjectCard() {
   return (
     <ul className="grid grid-cols-1 items-stretch gap-5 sm:grid-cols-2">
       {projects.map((project) => {
-        const isExternal = project.siteLink.startsWith('http');
+        const hasLink = project.siteLink && project.siteLink !== '#';
+        const isExternal = hasLink && project.siteLink.startsWith('http');
+        const cardContent = (
+          <div className="group relative grid h-full gap-4 pb-1 lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
+            <div className="sm:order-2 sm:col-span-6">
+              <h3 className="font-medium leading-snug">{project.title}</h3>
+
+              <p className="mt-2 text-sm leading-normal text-[var(--text-muted)]">
+                {project.description}
+              </p>
+              <ul className="mt-2 flex flex-wrap" aria-label="Technologies used:">
+                {project.stacks.map((stack) => {
+                  const tech = techMap[stack];
+                  return (
+                    <li key={stack}>
+                      <div className="flex items-center py-1 pr-3 text-sm leading-5">
+                        {tech && (
+                          <img
+                            src={getTechIconUrl(tech)}
+                            alt={`${tech.name} logo`}
+                            className="mr-1 inline-block h-3 w-3"
+                          />
+                        )}
+                        <span className="text-[var(--text-muted)]">{stack}</span>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </div>
+        );
+
+        const className =
+          'border-neutral-150 outline-hidden grid gap-2.5 overflow-hidden rounded-xl border px-5 py-4 focus-within:bg-neutral-100 hover:bg-neutral-100 focus:border-neutral-300 dark:border-neutral-800 dark:focus-within:bg-neutral-900 dark:hover:bg-neutral-900 dark:focus:border-neutral-700';
+
         return (
           <li key={project.title}>
-            <a
-              className="border-neutral-150 outline-hidden grid gap-2.5 overflow-hidden rounded-xl border px-5 py-4 focus-within:bg-neutral-100 hover:bg-neutral-100 focus:border-neutral-300 dark:border-neutral-800 dark:focus-within:bg-neutral-900 dark:hover:bg-neutral-900 dark:focus:border-neutral-700"
-              href={project.siteLink}
-              target={isExternal ? '_blank' : undefined}
-              rel={isExternal ? 'noreferrer noopener' : undefined}
-              aria-label={
-                isExternal ? `${project.ariaLabel} (opens in a new tab)` : project.ariaLabel
-              }
-            >
-              <div className="group relative grid h-full gap-4 pb-1 lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
-                <div className="sm:order-2 sm:col-span-6">
-                  <h3 className="font-medium leading-snug">{project.title}</h3>
-
-                  <p className="mt-2 text-sm leading-normal text-[var(--text-muted)]">
-                    {project.description}
-                  </p>
-                  <ul className="mt-2 flex flex-wrap" aria-label="Technologies used:">
-                    {project.stacks.map((stack) => {
-                      const tech = techMap[stack];
-                      return (
-                        <li key={stack}>
-                          <div className="flex items-center py-1 pr-3 text-sm leading-5">
-                            {tech && (
-                              <img
-                                src={getTechIconUrl(tech)}
-                                alt={`${tech.name} logo`}
-                                className="mr-1 inline-block h-3 w-3"
-                              />
-                            )}
-                            <span className="text-[var(--text-muted)]">{stack}</span>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
+            {hasLink ? (
+              <a
+                className={className}
+                href={project.siteLink}
+                target={isExternal ? '_blank' : undefined}
+                rel={isExternal ? 'noreferrer noopener' : undefined}
+                aria-label={
+                  isExternal ? `${project.ariaLabel} (opens in a new tab)` : project.ariaLabel
+                }
+              >
+                {cardContent}
+              </a>
+            ) : (
+              <div className={className} aria-disabled="true" aria-label={project.ariaLabel}>
+                {cardContent}
               </div>
-            </a>
+            )}
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- render a disabled container when `project.siteLink` is missing
- add tests for missing and existing project links

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d402e4e108322abc3ce5ffd0b326b