### PR TITLE
feat: sync body theme class

### DIFF
--- a/src/utils/themeToggle.test.ts
+++ b/src/utils/themeToggle.test.ts
@@ -4,6 +4,7 @@ import themeToggle from './themeToggle';
 describe('themeToggle', () => {
   beforeEach(() => {
     document.documentElement.classList.remove('dark');
+    document.body.classList.remove('dark');
     document.body.innerHTML = '';
     vi.useFakeTimers();
   });
@@ -22,6 +23,7 @@ describe('themeToggle', () => {
 
     expect(setDarkMode).toHaveBeenCalledWith(true);
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(true);
   });
 
   it('cleans up previous overlay on subsequent calls', () => {
@@ -32,9 +34,11 @@ describe('themeToggle', () => {
     themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
     const overlay = document.body.lastElementChild as HTMLElement;
     expect(overlay).toBeTruthy();
+    expect(document.body.classList.contains('dark')).toBe(true);
 
     themeToggle({ button, darkMode: true, setDarkMode, shouldReduceMotion: true });
     expect(overlay.isConnected).toBe(false);
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.body.classList.contains('dark')).toBe(false);
   });
 });

--- a/src/utils/themeToggle.ts
+++ b/src/utils/themeToggle.ts
@@ -42,6 +42,7 @@ export default function themeToggle({
     /* theme swap (instant) */
     setDarkMode(!darkMode);
     document.documentElement.classList.toggle('dark', !darkMode);
+    document.body.classList.toggle('dark', !darkMode);
 
     requestAnimationFrame(() => (overlay.style.opacity = '0'));
     const id = setTimeout(() => overlay.remove(), 210);
@@ -73,6 +74,7 @@ export default function themeToggle({
   if (!ctx) {
     setDarkMode(!darkMode);
     document.documentElement.classList.toggle('dark', !darkMode);
+    document.body.classList.toggle('dark', !darkMode);
     return;
   }
   ctx.scale(dpr, dpr);
@@ -109,6 +111,7 @@ export default function themeToggle({
   /* swap theme immediately so new colors are under the canvas */
   setDarkMode(!darkMode);
   document.documentElement.classList.toggle('dark', !darkMode);
+  document.body.classList.toggle('dark', !darkMode);
 
   /* animate: clear blocks inside radius */
   const start = performance.now();


### PR DESCRIPTION
## Summary
- sync `<body>` theme class with root for all theme swaps
- test immediate body updates in theme toggler

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689d40176fc48322901774524d8cf449