### PR TITLE
fix: use supported tailwind classes

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -11,7 +11,7 @@ export default function ProjectCard() {
         return (
           <li key={project.title}>
             <a
-              className="border-neutral-150 outline-hidden grid gap-2.5 overflow-hidden rounded-xl border px-5 py-4 focus-within:bg-neutral-100 hover:bg-neutral-100 focus:border-neutral-300 dark:border-neutral-800 dark:focus-within:bg-neutral-900 dark:hover:bg-neutral-900 dark:focus:border-neutral-700"
+              className="grid gap-2.5 overflow-hidden rounded-xl border border-neutral-200 px-5 py-4 outline-none focus-within:bg-neutral-100 hover:bg-neutral-100 focus:border-neutral-300 dark:border-neutral-800 dark:focus-within:bg-neutral-900 dark:hover:bg-neutral-900 dark:focus:border-neutral-700"
               href={project.siteLink}
               target={isExternal ? '_blank' : undefined}
               rel={isExternal ? 'noreferrer noopener' : undefined}


### PR DESCRIPTION
## Summary
- replace unsupported `border-neutral-150` with `border-neutral-200`
- swap `outline-hidden` for `outline-none`

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden when fetching vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689df96e661883229d9ccb722b1e6fb1