### PR TITLE
fix: guard matchMedia access

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
     <script>
       (function () {
         const stored = localStorage.getItem('darkMode');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const prefersDark = window.matchMedia
+          ? window.matchMedia('(prefers-color-scheme: dark)').matches
+          : false;
         const dark = stored === 'true' || (stored === null && prefersDark);
         if (dark) document.documentElement.classList.add('dark');
         window.addEventListener('DOMContentLoaded', () => {

--- a/src/components/visuals/CodeText.tsx
+++ b/src/components/visuals/CodeText.tsx
@@ -20,7 +20,10 @@ export default function CodeText() {
 
   useEffect(() => {
     if (!isDesktop()) return;
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const reduceMotion = window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
+    if (reduceMotion) return;
     setEnabled(true);
   }, []);
 

--- a/src/context/MotionContext.tsx
+++ b/src/context/MotionContext.tsx
@@ -15,6 +15,10 @@ export function MotionProvider({ children }: { children: ReactNode }) {
   const [shouldReduceMotion, setShouldReduceMotion] = useState(false);
 
   useEffect(() => {
+    if (!window.matchMedia) {
+      setShouldReduceMotion(false);
+      return;
+    }
     const query = window.matchMedia('(prefers-reduced-motion: reduce)');
     const update = () => setShouldReduceMotion(query.matches);
     update();

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -17,11 +17,10 @@ export default function useDarkMode(initial?: boolean): [boolean, (value: boolea
       if (stored !== null) return stored === 'true';
       if (initial !== undefined) return initial;
 
-      const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)');
-      return prefersDark?.matches ?? true; // defaults to dark mode
+      return window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)').matches : false; // safe fallback
     }
 
-    return initial ?? true; // safe fallback outside the browser
+    return initial ?? false; // safe fallback outside the browser
   };
 
   const [darkMode, setDarkModeState] = useState(getInitialDarkMode);
@@ -29,14 +28,18 @@ export default function useDarkMode(initial?: boolean): [boolean, (value: boolea
   useEffect(() => {
     if (!isBrowser) return;
 
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const html = document.documentElement;
+    const body = document.body;
+
+    let mediaQuery: MediaQueryList | undefined;
     const handleChange = (event: MediaQueryListEvent) => {
       setDarkModeState(event.matches);
     };
-    mediaQuery.addEventListener('change', handleChange);
 
-    const html = document.documentElement;
-    const body = document.body;
+    if (window.matchMedia) {
+      mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      mediaQuery.addEventListener('change', handleChange);
+    }
 
     if (darkMode) {
       html.classList.add('dark');
@@ -49,7 +52,7 @@ export default function useDarkMode(initial?: boolean): [boolean, (value: boolea
     window.localStorage.setItem('darkMode', String(darkMode));
 
     return () => {
-      mediaQuery.removeEventListener('change', handleChange);
+      mediaQuery?.removeEventListener('change', handleChange);
     };
   }, [darkMode, isBrowser]);
 


### PR DESCRIPTION
## Summary
- guard window.matchMedia usage and provide false fallback
- ensure motion, dark mode and visual components fail safely without matchMedia

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689df96babcc8322bd74ab53cf3046c9