### PR TITLE
fix: handle legacy media query listeners

### DIFF
--- a/src/context/MotionContext.tsx
+++ b/src/context/MotionContext.tsx
@@ -18,8 +18,12 @@ export function MotionProvider({ children }: { children: ReactNode }) {
     const query = window.matchMedia('(prefers-reduced-motion: reduce)');
     const update = () => setShouldReduceMotion(query.matches);
     update();
-    query.addEventListener('change', update);
-    return () => query.removeEventListener('change', update);
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', update);
+      return () => query.removeEventListener('change', update);
+    }
+    query.addListener(update);
+    return () => query.removeListener(update);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- ensure MotionContext uses addEventListener when available, falling back to addListener for older browsers

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689df968841c8322976e167cbfa155c7