### PR TITLE
fix: remove redundant image attributes

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -33,12 +33,10 @@ export default function Header() {
           <img
             alt="André Marinho"
             loading="lazy"
-            data-nimg="1"
             width={32}
             height={32}
             decoding="async"
             className="rounded-full"
-            style={{ color: 'transparent' }}
             src={me}
           />
         </a>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -35,7 +35,6 @@ export default function Hero() {
         </div>
         <img
           alt="André Marinho"
-          data-nimg="1"
           loading="lazy"
           width={176}
           height={176}


### PR DESCRIPTION
## Summary
- remove unused image attributes from header
- clean up hero image markup

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --run`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689df9645a788322892ed2767c89192d