### PR TITLE
Remove direct dark class manipulation in theme toggle

### DIFF
--- a/src/utils/themeToggle.test.ts
+++ b/src/utils/themeToggle.test.ts
@@ -22,8 +22,8 @@ describe('themeToggle', () => {
     themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
 
     expect(setDarkMode).toHaveBeenCalledWith(true);
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
-    expect(document.body.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.body.classList.contains('dark')).toBe(false);
   });
 
   it('cleans up previous overlay on subsequent calls', () => {
@@ -34,11 +34,13 @@ describe('themeToggle', () => {
     themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
     const overlay = document.body.lastElementChild as HTMLElement;
     expect(overlay).toBeTruthy();
-    expect(document.body.classList.contains('dark')).toBe(true);
+    expect(document.body.classList.contains('dark')).toBe(false);
 
     themeToggle({ button, darkMode: true, setDarkMode, shouldReduceMotion: true });
     expect(overlay.isConnected).toBe(false);
     expect(document.documentElement.classList.contains('dark')).toBe(false);
     expect(document.body.classList.contains('dark')).toBe(false);
+    expect(setDarkMode).toHaveBeenNthCalledWith(1, true);
+    expect(setDarkMode).toHaveBeenNthCalledWith(2, false);
   });
 });

--- a/src/utils/themeToggle.ts
+++ b/src/utils/themeToggle.ts
@@ -41,8 +41,6 @@ export default function themeToggle({
     document.body.appendChild(overlay);
     /* theme swap (instant) */
     setDarkMode(!darkMode);
-    document.documentElement.classList.toggle('dark', !darkMode);
-    document.body.classList.toggle('dark', !darkMode);
 
     requestAnimationFrame(() => (overlay.style.opacity = '0'));
     const id = setTimeout(() => overlay.remove(), 210);
@@ -73,8 +71,6 @@ export default function themeToggle({
   const ctx = canvas.getContext('2d');
   if (!ctx) {
     setDarkMode(!darkMode);
-    document.documentElement.classList.toggle('dark', !darkMode);
-    document.body.classList.toggle('dark', !darkMode);
     return;
   }
   ctx.scale(dpr, dpr);
@@ -110,8 +106,6 @@ export default function themeToggle({
 
   /* swap theme immediately so new colors are under the canvas */
   setDarkMode(!darkMode);
-  document.documentElement.classList.toggle('dark', !darkMode);
-  document.body.classList.toggle('dark', !darkMode);
 
   /* animate: clear blocks inside radius */
   const start = performance.now();


### PR DESCRIPTION
## Summary
- rely on `setDarkMode` and hook effects instead of manipulating `dark` classes directly
- update theme toggle tests to reflect DOM class behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_689df96271288322ba7b33800d990a41