### PR TITLE
fix: prevent white flash during theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,12 @@
     <link rel="icon" href="/favicon.ico" />
     <title>André Marinho - Front End Developer</title>
     <style>
-      html {
+      html,
+      body {
         background-color: #fff;
       }
-      html.dark {
+      html.dark,
+      html.dark body {
         background-color: #111827;
       }
     </style>

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   min-height: 100%;
   color: var(--text-color);
+  background-color: var(--background);
 }
 
 body {

--- a/src/utils/themeToggle.test.ts
+++ b/src/utils/themeToggle.test.ts
@@ -40,6 +40,18 @@ describe('themeToggle', () => {
     expect(overlay.style.background).toBe('rgb(17, 24, 39)');
   });
 
+  it('falls back to body background color if root is transparent', () => {
+    document.documentElement.style.backgroundColor = 'transparent';
+    document.body.style.backgroundColor = '#111827';
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const setDarkMode = vi.fn();
+
+    themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
+    const overlay = document.body.lastElementChild as HTMLElement;
+    expect(overlay.style.background).toBe('rgb(17, 24, 39)');
+  });
+
   it('cleans up previous overlay on subsequent calls', () => {
     const button = document.createElement('button');
     document.body.appendChild(button);

--- a/src/utils/themeToggle.test.ts
+++ b/src/utils/themeToggle.test.ts
@@ -5,6 +5,8 @@ describe('themeToggle', () => {
   beforeEach(() => {
     document.documentElement.classList.remove('dark');
     document.body.classList.remove('dark');
+    document.documentElement.style.backgroundColor = '';
+    document.body.style.backgroundColor = '';
     document.body.innerHTML = '';
     vi.useFakeTimers();
   });
@@ -24,6 +26,18 @@ describe('themeToggle', () => {
     expect(setDarkMode).toHaveBeenCalledWith(true);
     expect(document.documentElement.classList.contains('dark')).toBe(false);
     expect(document.body.classList.contains('dark')).toBe(false);
+  });
+
+  it('uses root background color for overlay', () => {
+    document.documentElement.style.backgroundColor = '#111827';
+    document.body.style.backgroundColor = '#ffffff';
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const setDarkMode = vi.fn();
+
+    themeToggle({ button, darkMode: false, setDarkMode, shouldReduceMotion: true });
+    const overlay = document.body.lastElementChild as HTMLElement;
+    expect(overlay.style.background).toBe('rgb(17, 24, 39)');
   });
 
   it('cleans up previous overlay on subsequent calls', () => {

--- a/src/utils/themeToggle.ts
+++ b/src/utils/themeToggle.ts
@@ -32,7 +32,7 @@ export default function themeToggle({
     Object.assign(overlay.style, {
       position: 'fixed',
       inset: '0',
-      background: getComputedStyle(document.body).backgroundColor,
+      background: getComputedStyle(document.documentElement).backgroundColor,
       pointerEvents: 'none',
       transition: 'opacity 200ms',
       zIndex: '9999',
@@ -100,7 +100,7 @@ export default function themeToggle({
   cells.sort((a, b) => a.dist - b.dist); // ascending
 
   /* paint screen with OLD color */
-  const oldColor = getComputedStyle(document.body).backgroundColor;
+  const oldColor = getComputedStyle(document.documentElement).backgroundColor;
   ctx.fillStyle = oldColor;
   ctx.fillRect(0, 0, w, h);
 

--- a/src/utils/themeToggle.ts
+++ b/src/utils/themeToggle.ts
@@ -12,6 +12,14 @@ export interface themeToggleOptions {
 
 let activeCleanup: (() => void) | null = null;
 
+function getBackgroundColor(): string {
+  const rootColor = getComputedStyle(document.documentElement).backgroundColor;
+  if (rootColor && rootColor !== 'rgba(0, 0, 0, 0)' && rootColor !== 'transparent') {
+    return rootColor;
+  }
+  return getComputedStyle(document.body).backgroundColor;
+}
+
 export default function themeToggle({
   button,
   darkMode,
@@ -32,7 +40,7 @@ export default function themeToggle({
     Object.assign(overlay.style, {
       position: 'fixed',
       inset: '0',
-      background: getComputedStyle(document.documentElement).backgroundColor,
+      background: getBackgroundColor(),
       pointerEvents: 'none',
       transition: 'opacity 200ms',
       zIndex: '9999',
@@ -100,7 +108,7 @@ export default function themeToggle({
   cells.sort((a, b) => a.dist - b.dist); // ascending
 
   /* paint screen with OLD color */
-  const oldColor = getComputedStyle(document.documentElement).backgroundColor;
+  const oldColor = getBackgroundColor();
   ctx.fillStyle = oldColor;
   ctx.fillRect(0, 0, w, h);
 


### PR DESCRIPTION
## Summary
- use document.documentElement for background color to avoid flash during theme changes
- ensure body shares background color with root element
- test overlay uses root background color

## Testing
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68ab04301bdc8322a3a347f0bd99b910