### PR TITLE
feat: add project tags

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -21,6 +21,11 @@ export default function ProjectCard() {
             >
               <div className="group relative grid h-full gap-4 pb-1 lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
                 <div className="sm:order-2 sm:col-span-6">
+                  {project.tag && (
+                    <span className="mb-2 inline-block rounded-full bg-neutral-200 px-2 py-0.5 text-xs font-medium text-neutral-800 dark:bg-neutral-700 dark:text-neutral-200">
+                      {project.tag}
+                    </span>
+                  )}
                   <h3 className="font-medium leading-snug">{project.title}</h3>
 
                   <p className="mt-2 text-sm leading-normal text-[var(--text-muted)]">

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -6,7 +6,7 @@ import { ProjectCard } from '@/components';
 export default function Projects() {
   return (
     <section id="projects" aria-label="Selected projects">
-      <h2 className="my-6 block text-lg font-bold">Selected Projects</h2>
+      <h2 className="my-6 block text-lg font-bold">Projects</h2>
       <ProjectCard />
     </section>
   );

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -7,6 +7,7 @@ export const projects: Project[] = [
     ariaLabel: 'Turistar travel planner',
     description: 'Interactive trip planner with drag-and-drop features. 🗺️',
     siteLink: 'https://travel-planner-orpin.vercel.app/',
+    tag: 'Selected Project',
     stacks: ['Next.js', 'TypeScript'],
   },
   {

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -6,6 +6,7 @@ export interface Project {
   description: string;
   siteLink: string;
   stacks: string[];
+  tag?: string;
 }
 
 export interface Tech {


### PR DESCRIPTION
## Summary
- rename Projects section heading
- add optional project tag and display badge when present

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run vercel:build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68ad070122288322904526ef1e1fc5d0