### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,49 @@
+name: Lighthouse
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Disable Next.js telemetry
+        run: npx next telemetry disable
+
+      - name: Build application
+        run: npm run build:prod
+
+      - name: Run Lighthouse CI
+        id: lhci
+        continue-on-error: true
+        run: npx start-server-and-test "npm run serve:prod" http://127.0.0.1:3000 "npm run lhci"
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lhci-reports
+          path: lhci-reports
+          if-no-files-found: ignore
+
+      - name: Check Lighthouse assertions
+        if: steps.lhci.outcome == 'failure'
+        run: exit 1

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://127.0.0.1:3000/"],
+      "numberOfRuns": 1
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": "lhci-reports"
+    },
+    "assert": {
+      "preset": "lighthouse:recommended"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
         "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,css,md}\"",
         "lint": "next lint",
         "lint:ci": "next lint --max-warnings=0",
+        "serve:prod": "next start --hostname 0.0.0.0 --port 3000",
         "start": "next start",
         "test": "jest",
         "test:ci": "jest --ci",
         "typecheck": "tsc --noEmit",
-        "vercel:build": "next build"
+        "vercel:build": "next build",
+        "lhci": "npx --yes @lhci/cli autorun --config=./lighthouserc.json"
     },
     "dependencies": {
         "classix": "^2.2.4",


### PR DESCRIPTION
## Summary
- add a Lighthouse GitHub Actions workflow that builds the app and runs LHCI with reports uploaded as artifacts
- expose npm scripts for serving the production build and invoking LHCI via npx
- define a Lighthouse CI configuration that targets the production server and saves reports to disk

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run vercel:build *(fails: unable to fetch Inter font from Google Fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc97baf7883229a2ee03dd33d23c9