### PR TITLE
Configure Lighthouse CI settings

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,15 +1,44 @@
 {
   "ci": {
     "collect": {
-      "url": ["http://127.0.0.1:3000/"],
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/about",
+        "http://localhost:3000/studio"
+      ],
       "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:best-practices": [
+          "warn",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "warn",
+          {
+            "minScore": 0.9
+          }
+        ]
+      }
     },
     "upload": {
       "target": "filesystem",
-      "outputDir": "lhci-reports"
-    },
-    "assert": {
-      "preset": "lighthouse:recommended"
+      "outputDir": "./lhci-reports"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the Lighthouse CI configuration to collect the homepage, about, and studio pages with one run each
- enforce minimum Lighthouse thresholds for performance and accessibility while warning on best-practices and SEO
- upload Lighthouse CI artifacts to a filesystem directory for publishing

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build *(fails: unable to fetch the Inter font because of restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd540339c8322bf7b7b55150b3f65