### PR TITLE
fix: load Inter font locally

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
+import localFont from 'next/font/local';
 import React from 'react';
 
 import './globals.css';
@@ -7,7 +7,13 @@ import { SiteLayout } from '@/components/layout';
 import cn from '@/utils/cn';
 import { AppProviders } from './providers';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const inter = localFont({
+  src: [
+    { path: '../../public/fonts/inter.var.latin.woff2', style: 'normal' },
+    { path: '../../public/fonts/inter.var.latin.italic.woff2', style: 'italic' },
+  ],
+  variable: '--font-inter',
+});
 
 export const metadata: Metadata = {
   title: 'Andre Marinho - Front-End Developer',


### PR DESCRIPTION
## Summary
- replace the Google Inter font with a local font loader that reads the bundled variable font files so the existing className usage continues to work

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68ccd6e971208322bf57a2ea5b4d6dda