### PR TITLE
fix: avoid mouse coordinate rerenders

### DIFF
--- a/src/components/visuals/CodeText.tsx
+++ b/src/components/visuals/CodeText.tsx
@@ -1,6 +1,6 @@
 ﻿'use client';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import cn from '@/utils/cn';
 import { useMouseCoords } from '@/hooks';


### PR DESCRIPTION
## Summary
- store mouse coordinates in refs within `useMouseCoords`, update CSS variables directly, and allow an optional change callback
- keep `CodeText` free of unnecessary React state imports so it can depend on the ref-based mouse tracking without re-renders

## Testing
- npm run format
- npm run lint
- npm run test -- --runInBand
- npm run typecheck
- npm run vercel:build
- npm run lhci *(fails: npm 403 Forbidden when fetching @lhci/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4712ca988322bf7d29a1a55dc86f