### PR TITLE
fix: remove react-remove-scroll from hamburger menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "next": "^14.2.5",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-remove-scroll": "^2.7.1",
                 "tailwind-merge": "^3.3.1"
             },
             "devDependencies": {
@@ -1956,14 +1955,14 @@
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.24",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
             "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -3637,7 +3636,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
@@ -3871,12 +3870,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/detect-node-es": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-            "license": "MIT"
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -5205,15 +5198,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-nonce": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/get-package-type": {
@@ -8820,75 +8804,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/react-remove-scroll": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-            "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
-            "license": "MIT",
-            "dependencies": {
-                "react-remove-scroll-bar": "^2.3.7",
-                "react-style-singleton": "^2.2.3",
-                "tslib": "^2.1.0",
-                "use-callback-ref": "^1.3.3",
-                "use-sidecar": "^1.1.3"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-remove-scroll-bar": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-            "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-            "license": "MIT",
-            "dependencies": {
-                "react-style-singleton": "^2.2.2",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/react-style-singleton": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-            "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-            "license": "MIT",
-            "dependencies": {
-                "get-nonce": "^1.0.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/read-cache": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -10535,49 +10450,6 @@
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
-            }
-        },
-        "node_modules/use-callback-ref": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/use-sidecar": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "detect-node-es": "^1.1.0",
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "@types/react": "*",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "next": "^14.2.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-remove-scroll": "^2.7.1",
         "tailwind-merge": "^3.3.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary
- replace the mobile navigation scroll lock with a native implementation and manual focus trapping
- add dialog semantics to the hamburger menu overlay for improved accessibility
- drop the unused `react-remove-scroll` dependency from the project

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run build
- npm run vercel:build
- npm run lhci *(fails: npm 403 fetching @lhci/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68cd538bd5808322ad252c0b4d1a0aa8