### PR TITLE
fix: prioritize hero portrait image loading

### DIFF
--- a/src/app/home/components/Hero.tsx
+++ b/src/app/home/components/Hero.tsx
@@ -41,10 +41,11 @@ export default function Hero() {
         </div>
         <Image
           alt="Andre Marinho"
-          loading="lazy"
           width={176}
           height={176}
           className="hidden h-44 w-44 transform-gpu rounded-full sm:block"
+          priority
+          fetchPriority="high"
           src="/images/Me.webp"
           sizes="176px"
         />


### PR DESCRIPTION
## Summary
- prioritize the hero portrait image loading to improve LCP by marking it as high priority

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build
- npm run lhci *(fails: 403 Forbidden fetching @lhci/cli from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cd57dc35688322ba888c5d311b070d