### PR TITLE
Extract layout visuals into client wrapper

### DIFF
--- a/src/components/layout/ClientVisuals.tsx
+++ b/src/components/layout/ClientVisuals.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+
+import AnimationBG from '@/components/visuals/BGAnimation';
+import CodeText from '@/components/visuals/CodeText';
+
+export default function ClientVisuals() {
+  return (
+    <>
+      <AnimationBG />
+      <CodeText />
+    </>
+  );
+}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,13 +1,10 @@
-﻿'use client';
-
 import dynamic from 'next/dynamic';
 import React from 'react';
 
 import Footer from './Footer';
 import Header from './NavigationMenu';
 
-const AnimationBG = dynamic(() => import('@/components/visuals/BGAnimation'), { ssr: false });
-const CodeText = dynamic(() => import('@/components/visuals/CodeText'), { ssr: false });
+const ClientVisuals = dynamic(() => import('./ClientVisuals'), { ssr: false });
 
 type SiteLayoutProps = {
   children: React.ReactNode;
@@ -20,8 +17,7 @@ export function SiteLayout({ children }: SiteLayoutProps) {
       <main id="main">{children}</main>
       <Footer />
       <div className="pointer-events-none" aria-hidden>
-        <AnimationBG />
-        <CodeText />
+        <ClientVisuals />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- remove the `use client` directive from the site layout so it can render on the server
- create a client-only `ClientVisuals` wrapper for the background animation and code text
- import the new wrapper dynamically in the layout to preserve the existing conditional rendering

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- CI=1 npm run vercel:build
- CI=1 npm run build
- npm run lhci *(fails: npm 403 fetching @lhci/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68cd57c896e48322ae1c3e77f7cd8f3b