### PR TITLE
fix: keep mobile menu open until navigation completes

### DIFF
--- a/src/components/layout/NavigationMenu/Hamburger.tsx
+++ b/src/components/layout/NavigationMenu/Hamburger.tsx
@@ -134,7 +134,7 @@ export default function Hamburger({ isOpen, setIsOpen, links }: HamburgerProps) 
               <X className="h-6 w-6" aria-hidden="true" />
             </button>
           </div>
-          <Links links={links} variant="mobile" onSelect={() => setIsOpen(false)} />
+          <Links links={links} variant="mobile" />
         </nav>
       )}
     </div>


### PR DESCRIPTION
## Summary
- remove the mobile navigation Links onSelect handler so the overlay stays visible until the pathname change triggers the closing effect

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build
- npm run dev (manual mobile navigation validation)


------
https://chatgpt.com/codex/tasks/task_e_68cd83d8eb608322b5cee971e72ed902