### PR TITLE
fix: align theme toggle icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,7 +53,7 @@
   }
 
   h1 {
-    @apply m-0 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-zinc-100;
+    @apply m-0 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 sm:text-4xl;
   }
 
   h2 {

--- a/src/components/layout/NavigationMenu/ThemeSelector.tsx
+++ b/src/components/layout/NavigationMenu/ThemeSelector.tsx
@@ -27,14 +27,16 @@ export default function ThemeSelector({ hidden = false }: ThemeSelectorProps) {
       aria-pressed={darkMode}
       type="button"
     >
-      <Moon
-        aria-hidden="true"
-        className="block h-5 w-5 shrink-0 text-zinc-700 transition-all duration-300 group-hover:rotate-12 dark:hidden dark:text-zinc-300"
-      />
-      <Sun
-        aria-hidden="true"
-        className="hidden h-5 w-5 shrink-0 text-zinc-100 transition-all duration-300 group-hover:rotate-180 dark:block"
-      />
+      <span className="relative flex h-5 w-5 items-center justify-center">
+        <Moon
+          aria-hidden="true"
+          className="absolute inset-0 h-5 w-5 shrink-0 text-zinc-700 opacity-100 transition-all duration-300 group-hover:rotate-12 dark:text-zinc-300 dark:opacity-0"
+        />
+        <Sun
+          aria-hidden="true"
+          className="absolute inset-0 h-5 w-5 shrink-0 text-zinc-100 opacity-0 transition-all duration-300 group-hover:rotate-180 dark:opacity-100"
+        />
+      </span>
     </button>
   );
 }

--- a/src/components/layout/NavigationMenu/ThemeSelector.tsx
+++ b/src/components/layout/NavigationMenu/ThemeSelector.tsx
@@ -29,11 +29,11 @@ export default function ThemeSelector({ hidden = false }: ThemeSelectorProps) {
     >
       <Moon
         aria-hidden="true"
-        className="h-5 w-5 text-zinc-700 transition-all duration-300 group-hover:rotate-12 dark:hidden dark:text-zinc-300"
+        className="block h-5 w-5 shrink-0 text-zinc-700 transition-all duration-300 group-hover:rotate-12 dark:hidden dark:text-zinc-300"
       />
       <Sun
         aria-hidden="true"
-        className="hidden h-5 w-5 text-zinc-100 transition-all duration-300 group-hover:rotate-180 dark:block"
+        className="hidden h-5 w-5 shrink-0 text-zinc-100 transition-all duration-300 group-hover:rotate-180 dark:block"
       />
     </button>
   );

--- a/src/components/layout/NavigationMenu/index.tsx
+++ b/src/components/layout/NavigationMenu/index.tsx
@@ -24,7 +24,7 @@ export default function NavigationMenu() {
   return (
     <header
       className={cn(
-        'sticky top-0 z-40 bg-white/75 py-2 sm:py-3 dark:bg-zinc-950/75',
+        'sticky top-0 z-40 bg-white/75 py-2 dark:bg-zinc-950/75 sm:py-3',
         isHamburgerOpen ? '' : 'backdrop-blur-xl'
       )}
     >


### PR DESCRIPTION
## Summary
- ensure the Moon and Sun icons in the theme selector render with identical block sizing to prevent header shift
- update formatted Tailwind class ordering in layout styles after running the formatter

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68ce115376848322b6d0ce79cda4fa36