### PR TITLE
Fix Tailwind Inter font integration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,34 +7,12 @@
    Global Base Styles
    ================================ */
 @layer base {
-  @font-face {
-    font-family: 'InterVariable';
-    font-style: normal;
-    font-weight: 100 900;
-    font-display: swap;
-    src: url('/fonts/inter.var.latin.woff2') format('woff2');
-  }
-
-  @font-face {
-    font-family: 'InterVariable';
-    font-style: italic;
-    font-weight: 100 900;
-    font-display: swap;
-    src: url('/fonts/inter.var.latin.italic.woff2') format('woff2');
-  }
-
   html {
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     min-height: 100%;
-    font-family:
-      'InterVariable',
-      'Inter',
-      system-ui,
-      -apple-system,
-      'Segoe UI',
-      sans-serif;
+    @apply font-sans;
   }
 
   body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={cn(inter.variable, 'antialiased')}>
+      <body className={cn(inter.variable, 'font-sans antialiased')}>
         <AppProviders>
           <SiteLayout>{children}</SiteLayout>
         </AppProviders>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,18 +1,17 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
 /** @type {import('tailwindcss').Config} */
 const config = {
   darkMode: 'class',
   content: {
-    files: [
-      './src/app/**/*.{js,jsx,ts,tsx,mdx}',
-      './src/components/**/*.{js,jsx,ts,tsx,mdx}',
-      './src/context/**/*.{js,jsx,ts,tsx,mdx}',
-      './src/hooks/**/*.{js,jsx,ts,tsx,mdx}',
-      './src/utils/**/*.{js,jsx,ts,tsx,mdx}',
-    ],
+    files: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
     relative: import.meta.url,
   },
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', ...defaultTheme.fontFamily.sans],
+      },
       keyframes: {
         float: {
           '0%,100%': { transform: 'translateY(0)' },


### PR DESCRIPTION
## Summary
- remove the redundant Inter @font-face declarations and lean on next/font local loading
- prepend the Inter CSS variable to Tailwind's sans stack and ensure the root uses the sans utility
- simplify the html base rule now that the Tailwind font family handles the stack
- align the global h1 @apply ordering with Prettier so `npm run format` completes cleanly
- collapse the Tailwind content configuration to a single src-wide glob so linting picks up every utility usage

## Testing
- npm run format
- npm run lint
- CI=true npm run test
- npm run typecheck
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68ce177c39908322aafe5203fcde83d8