### PR TITLE
feat: centralize studio CTA helper

### DIFF
--- a/src/app/studio/components/FinalCTA.tsx
+++ b/src/app/studio/components/FinalCTA.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import StudioCta from '@/components/common/StudioCta';
 import type React from 'react';
 import { useRef, useState } from 'react';
 
@@ -77,14 +78,13 @@ const FinalCTA = () => {
           </div>
         </div>
 
-        <a
-          href="https://wa.me/5571984770061"
+        <StudioCta
+          className="inline-flex rounded-xl px-6"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex rounded-xl bg-gradient-to-b from-orange-500 to-orange-600 px-6 py-2 font-semibold text-white antialiased shadow-[inset_0_1px_0_0.75px_rgba(255,255,255,0.2)] transition-transform will-change-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 active:scale-[.97]"
         >
           Get started
-        </a>
+        </StudioCta>
       </div>
     </section>
   );

--- a/src/app/studio/components/Hero.tsx
+++ b/src/app/studio/components/Hero.tsx
@@ -1,3 +1,5 @@
+import StudioCta from '@/components/common/StudioCta';
+
 import TextType from './TextType';
 
 const Hero = () => {
@@ -16,14 +18,9 @@ const Hero = () => {
         We help business build high-quality products and delightful digital experiences.
       </p>
 
-      <a
-        href="https://wa.me/5571984770061"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex rounded-xl bg-gradient-to-b from-orange-500 to-orange-600 px-6 py-2 font-semibold text-white antialiased shadow-[inset_0_1px_0_0.75px_rgba(255,255,255,0.2)] transition-transform will-change-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 active:scale-[.97]"
-      >
+      <StudioCta className="inline-flex rounded-xl px-6" target="_blank" rel="noopener noreferrer">
         Book a call
-      </a>
+      </StudioCta>
     </section>
   );
 };

--- a/src/app/studio/components/Pricing.tsx
+++ b/src/app/studio/components/Pricing.tsx
@@ -1,3 +1,5 @@
+import StudioCta from '@/components/common/StudioCta';
+
 interface PricingCardProps {
   tier: string;
   price: string;
@@ -15,14 +17,13 @@ const PricingCard = ({ tier, price, description, features = [] }: PricingCardPro
         <span className="text-3xl font-bold">{price}</span>
         {price !== 'Custom' && <span className="text-zinc-500 dark:text-zinc-400">/ one-time</span>}
       </p>
-      <a
-        href="https://wa.me/5571984770061"
+      <StudioCta
+        className="block w-full rounded-lg text-center"
         target="_blank"
         rel="noopener noreferrer"
-        className="block w-full rounded-lg bg-gradient-to-b from-orange-500 to-orange-600 py-2 text-center font-semibold text-white antialiased shadow-[inset_0_1px_0_0.75px_rgba(255,255,255,0.2)] transition-transform will-change-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 active:scale-[.97]"
       >
         Start a project
-      </a>
+      </StudioCta>
       <ul className="mt-6 space-y-2 text-sm text-zinc-700 dark:text-zinc-300">
         {features.map((feature, index) => (
           <li key={index} className="flex items-start gap-2">
@@ -72,14 +73,14 @@ const Pricing = () => {
             chat and see how we can help you.
           </p>
         </div>
-        <a
-          href="https://wa.me/5571984770061"
-          target="_blank"
+        <StudioCta
+          className="inline-flex items-center justify-center gap-x-1.5 rounded-lg px-6"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center gap-x-1.5 rounded-lg border border-zinc-200 px-6 py-2 text-sm font-semibold antialiased shadow-xs transition-transform will-change-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-400 active:scale-[.99] dark:border-zinc-800 dark:bg-neutral-900 dark:focus-visible:outline-neutral-500"
+          target="_blank"
+          variant="secondary"
         >
           Book a call
-        </a>
+        </StudioCta>
       </div>
     </section>
   );

--- a/src/components/common/StudioCta.tsx
+++ b/src/components/common/StudioCta.tsx
@@ -1,0 +1,37 @@
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import { WHATSAPP_LINK } from '@/data/links';
+import cn from '@/utils/cn';
+
+type StudioCtaProps = ComponentPropsWithoutRef<'a'> & {
+  readonly children: ReactNode;
+  readonly variant?: 'primary' | 'secondary';
+};
+
+const baseClasses =
+  'font-semibold antialiased py-2 transition-transform will-change-transform focus-visible:outline-2 focus-visible:outline-offset-2';
+
+const variantClasses = {
+  primary:
+    'bg-gradient-to-b from-orange-500 to-orange-600 text-white shadow-[inset_0_1px_0_0.75px_rgba(255,255,255,0.2)] focus-visible:outline-orange-500 active:scale-[.97]',
+  secondary:
+    'border border-zinc-200 text-sm shadow-xs focus-visible:outline-neutral-400 active:scale-[.99] dark:border-zinc-800 dark:bg-neutral-900 dark:focus-visible:outline-neutral-500',
+} as const satisfies Record<NonNullable<StudioCtaProps['variant']>, string>;
+
+const StudioCta = forwardRef<HTMLAnchorElement, StudioCtaProps>(
+  ({ href = WHATSAPP_LINK, variant = 'primary', className, children, ...props }, ref) => (
+    <a
+      ref={ref}
+      href={href}
+      className={cn(baseClasses, variantClasses[variant], className)}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+);
+
+StudioCta.displayName = 'StudioCta';
+
+export default StudioCta;

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,5 +1,7 @@
 import type { ContactLink } from './types';
 
+export const WHATSAPP_LINK = 'https://wa.me/5571984770061';
+
 export const contactLinks: ContactLink[] = [
   {
     label: 'GitHub',


### PR DESCRIPTION
## Summary
- add a reusable `StudioCta` component with shared styling defaults and WhatsApp link
- centralize the WhatsApp contact URL in the data layer
- refactor studio Hero, Pricing, and FinalCTA sections to consume the helper

## Testing
- npm run lint
- npm run test
- npm run typecheck
- CI=1 npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68ce21e8f77c8322a88dcaa5bec43073