### PR TITLE
Refactor studio TextType with simplified typing effect

### DIFF
--- a/src/app/studio/components/Hero.tsx
+++ b/src/app/studio/components/Hero.tsx
@@ -6,9 +6,8 @@ const Hero = () => {
       <h1 className="pb-6 text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl">
         {'World-class '}
         <TextType
-          as="span"
           className="text-zinc-900 italic dark:text-zinc-100"
-          text={['design', 'software', 'product']}
+          texts={['design', 'software', 'product']}
         />
         <span className="block">partner for your business</span>
       </h1>

--- a/src/app/studio/components/TextType.test.tsx
+++ b/src/app/studio/components/TextType.test.tsx
@@ -1,0 +1,45 @@
+import { act, render, screen } from '@testing-library/react';
+
+import TextType from './TextType';
+
+describe('TextType', () => {
+  const advanceUntilTextIs = (expected: string) => {
+    const element = screen.getByTestId('typer');
+
+    for (let i = 0; i < 50; i += 1) {
+      if (element.textContent === expected) {
+        break;
+      }
+
+      act(() => {
+        jest.advanceTimersByTime(10);
+      });
+    }
+
+    expect(element.textContent).toBe(expected);
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('types and cycles through provided texts', () => {
+    render(
+      <TextType texts={['dev', 'ops']} typingDelay={10} pauseDuration={20} data-testid="typer" />
+    );
+
+    const element = screen.getByTestId('typer');
+    expect(element).toBeInTheDocument();
+    expect(element.textContent).toBe('');
+
+    advanceUntilTextIs('d');
+    advanceUntilTextIs('dev');
+    advanceUntilTextIs('');
+    advanceUntilTextIs('o');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the studio text typing component with a minimal interval-driven implementation and leaner props
- update the studio hero to use the new `texts` prop
- add a Jest test that covers the typing cycle

## Testing
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68ce2226c3b483229e6f823eded7ea6f