### PR TITLE
Add Vercel redirects and caching rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ npm run vercel:build
 
 ## Deployment
 
-The project is configured for Vercel. To validate the deployment locally run:
+The project is configured for Vercel:
+
+- Incoming traffic is normalized by `vercel.json`, which permanently redirects any HTTP requests to HTTPS and folds `www.andremarinho.me` into the apex domain for canonical URLs.
+- Long-lived caching headers (`Cache-Control: public,max-age=31536000,immutable`) are applied to hashed build artefacts, including `/_next/static/**`, `/_next/data/**`, and any files served with a fingerprinted filename.
+
+To validate the deployment locally run:
 
 ```bash
 npm run vercel:build

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,58 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "x-forwarded-proto",
+          "value": "http"
+        }
+      ],
+      "destination": "https://andremarinho.me/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "^www\\.andremarinho\\.me$"
+        }
+      ],
+      "destination": "https://andremarinho.me/:path*",
+      "permanent": true
+    }
+  ],
+  "headers": [
+    {
+      "source": "/_next/static/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public,max-age=31536000,immutable"
+        }
+      ]
+    },
+    {
+      "source": "/_next/data/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public,max-age=31536000,immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.:hash([a-f0-9]{8,}).:ext",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public,max-age=31536000,immutable"
+        }
+      ]
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
         {
           "type": "header",
           "key": "x-forwarded-proto",
-          "value": "http"
+          "value": "^http$"
         }
       ],
       "destination": "https://andremarinho.me/:path*",


### PR DESCRIPTION
## Summary
- add HTTPS enforcement and www-to-apex redirects to `vercel.json`
- set long-lived cache headers for hashed build assets
- document the redirect and caching behaviour in the deployment section of the README

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run test -- --runInBand
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68cf3585001c832287e9dc854d25fb0b