### PR TITLE
Add verify script and align CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,5 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: 1
         run: npm ci
-      - name: Prettier (check)
-        run: npm run format:check
-      - name: Lint
-        run: npm run lint:ci
-      - name: Type check
-        run: npm run typecheck
-      - name: Test
-        run: npm run test:ci
-      - name: Build
-        run: npm run build:prod
+      - name: Run CI verification
+        run: npm run ci

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ npm start
 - `npm run typecheck` - execute TypeScript in no-emit mode
 - `npm run test` - run Jest + Testing Library
 - `npm run test:ci` - run the Jest suite in CI mode for deterministic output
+- `npm run verify` - run formatting checks, linting, type checking, tests, and a production build sequentially
+- `npm run ci` - alias for `npm run verify` to mirror the GitHub Actions workflow locally
 - `npm run format` - format with Prettier
 - `npm run vercel:build` - build using the same command executed by Vercel
 
@@ -106,6 +108,7 @@ The `.vercel` directory is updated automatically by Vercel CLI builds.
 
 ### Local parity scripts
 
+- `npm run verify` – execute `format:check`, `lint:ci`, `typecheck`, `test:ci`, and `build:prod` together for full parity with CI.
 - `npm run format:check` – verify Prettier formatting before pushing, especially after touching Markdown or styles.
 - `npm run lint:ci` – run the stricter ESLint configuration used in CI to catch warnings early.
 - `npm run typecheck` – confirm TypeScript stays happy after API or prop changes.
@@ -115,7 +118,7 @@ The `.vercel` directory is updated automatically by Vercel CLI builds.
 
 ### GitHub Actions
 
-- **CI** – runs on pushes to `main` and every pull request. It installs dependencies, then executes `format:check`, `lint:ci`, `typecheck`, `test:ci`, and `build:prod` to mirror release gating.
+- **CI** – runs on pushes to `main` and every pull request. It installs dependencies, then runs `npm run ci` (aliasing `npm run verify`) to execute `format:check`, `lint:ci`, `typecheck`, `test:ci`, and `build:prod` for release gating.
 - **Lighthouse** – runs on pushes to `main`, every pull request, or when triggered manually. It builds the app, serves it, audits with Lighthouse CI, and uploads the `lhci-reports` artifact so regressions fail loudly.
 
 ### Retrieve Lighthouse reports

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "test": "jest",
         "test:ci": "jest --ci",
         "typecheck": "tsc --noEmit",
+        "verify": "npm run format:check && npm run lint:ci && npm run typecheck && npm run test:ci && npm run build:prod",
+        "ci": "npm run verify",
         "vercel:build": "next build",
         "lhci": "npx --yes @lhci/cli autorun --config=./lighthouserc.json"
     },


### PR DESCRIPTION
## Summary
- add combined `npm run verify` script and `npm run ci` alias for local/CI parity
- update the CI workflow to invoke the aggregated script instead of individual steps
- document the new scripts and parity workflow in the README

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run vercel:build
- npm run verify

------
https://chatgpt.com/codex/tasks/task_e_68cf4cbd55688322b58e8d270d5fb8f4