### PR TITLE
Fix hero image priority and add vercel module types

### DIFF
--- a/src/app/home/components/Hero.tsx
+++ b/src/app/home/components/Hero.tsx
@@ -41,12 +41,12 @@ export default function Hero() {
         </div>
         <Image
           alt="Andre Marinho"
-          loading="lazy"
           width={176}
           height={176}
           className="hidden h-44 w-44 transform-gpu rounded-full sm:block"
           src="/images/Me.webp"
           sizes="176px"
+          priority
         />
       </div>
     </section>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,13 @@
 declare module '*.webp';
+
+declare module '@vercel/analytics/next' {
+  import type { ComponentType } from 'react';
+
+  export const Analytics: ComponentType;
+}
+
+declare module '@vercel/speed-insights/next' {
+  import type { ComponentType } from 'react';
+
+  export const SpeedInsights: ComponentType;
+}


### PR DESCRIPTION
## Summary
- set the hero portrait to use Next.js priority loading instead of a manual lazy flag
- add ambient module declarations for Vercel analytics/speed-insights packages to keep type checking green

## Testing
- npm run lint
- npm run typecheck
- npm run test -- --runInBand
- npm run vercel:build
- LHCI_COLLECT__CHROME_PATH=$(which google-chrome-stable) LHCI_COLLECT__SETTINGS__CHROME_FLAGS="--headless --no-sandbox --disable-dev-shm-usage" npm run lhci

------
https://chatgpt.com/codex/tasks/task_e_68cf6056fc2483229d913a2dbed034ca