### PR TITLE
fix: close hamburger menu using aria state

### DIFF
--- a/src/components/layout/NavigationMenu/Hamburger.tsx
+++ b/src/components/layout/NavigationMenu/Hamburger.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
 import { Menu, X } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
@@ -22,6 +23,23 @@ export default function Hamburger({ isOpen, setIsOpen }: Props) {
   const pathname = usePathname();
   const navRef = useRef<HTMLElement | null>(null);
   const openButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Close the menu immediately when the current page is selected again or an external link opens.
+  const handleNavClick = (event: ReactMouseEvent<HTMLElement>) => {
+    const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>('a');
+    if (!anchor) return;
+
+    const href = anchor.getAttribute('href');
+    if (!href) return;
+
+    if (
+      anchor.target === '_blank' ||
+      href.startsWith('http') ||
+      anchor.getAttribute('aria-current') === 'page'
+    ) {
+      setIsOpen(false);
+    }
+  };
 
   useEffect(() => {
     setIsOpen(false);
@@ -105,6 +123,7 @@ export default function Hamburger({ isOpen, setIsOpen }: Props) {
           role="dialog"
           aria-modal="true"
           tabIndex={-1}
+          onClick={handleNavClick}
         >
           <div className="absolute right-0 px-6 py-2">
             <button

--- a/src/components/layout/NavigationMenu/Links.tsx
+++ b/src/components/layout/NavigationMenu/Links.tsx
@@ -6,13 +6,11 @@ import { usePathname } from 'next/navigation';
 type Props = {
   links: { href: `/${string}` | `https://${string}`; text: string }[];
   isHamburguer?: boolean;
-  onSelect?: () => void;
 };
 
-const Links = ({ links, isHamburguer, onSelect }: Props) => {
+const Links = ({ links, isHamburguer }: Props) => {
   const pathname = `/${usePathname()?.split('/')[1] ?? ''}`;
   const isIndeterminate = links.every((l) => l.href !== pathname);
-  const handle = onSelect ? () => onSelect() : undefined;
 
   return (
     <ul
@@ -24,7 +22,7 @@ const Links = ({ links, isHamburguer, onSelect }: Props) => {
     >
       {links.map(({ href, text }) => {
         const external = href.startsWith('http');
-        const isActive = href === pathname;
+        const isActive = !external && href === pathname;
         const state = isIndeterminate
           ? 'hover:opacity-60'
           : isActive
@@ -35,13 +33,7 @@ const Links = ({ links, isHamburguer, onSelect }: Props) => {
         return (
           <li key={href}>
             {external ? (
-              <a
-                href={href}
-                className={className}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={handle}
-              >
+              <a href={href} className={className} target="_blank" rel="noopener noreferrer">
                 {text}
               </a>
             ) : (
@@ -49,7 +41,6 @@ const Links = ({ links, isHamburguer, onSelect }: Props) => {
                 href={href}
                 className={className}
                 aria-current={isActive ? 'page' : undefined}
-                onClick={handle}
               >
                 {text}
               </NextLink>


### PR DESCRIPTION
## Summary
- close the hamburger navigation when the active entry is clicked again by relying on its aria-current state, keeping other link usages untouched while still handling external targets

## Testing
- npm run format
- npm run lint
- npm run test
- CI=1 npm run test
- npm run typecheck
- CI=1 npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d03bc8445c8322a5302b590297d4a4