### PR TITLE
Fix Lighthouse warmup to run against the live server

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,20 +31,12 @@ jobs:
       - name: Build application
         run: npm run build:prod
 
-      - name: Warm up server
-        run: |
-          for i in 1 2 3; do
-            curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3000/;
-            curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3000/about;
-            curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3000/studio;
-          done
-
       - name: Run Lighthouse CI
         id: lhci
         continue-on-error: true
         run: |
           set +e
-          npx start-server-and-test "npm run serve:prod" http://127.0.0.1:3000 "npm run lhci"
+          npx start-server-and-test "npm run serve:prod" http://127.0.0.1:3000 "npm run warmup && npm run lhci"
           status=$?
           echo "exit_code=$status" >> "$GITHUB_OUTPUT"
           if [ -f ".lighthouseci/assertion-results.json" ]; then

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "verify": "npm run format:check && npm run lint:ci && npm run typecheck && npm run test:ci && npm run build:prod",
         "ci": "npm run verify",
         "vercel:build": "next build",
+        "warmup": "bash ./scripts/warmup.sh",
         "lhci": "npx --yes @lhci/cli autorun --config=./lighthouserc.json"
     },
     "dependencies": {

--- a/scripts/warmup.sh
+++ b/scripts/warmup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://127.0.0.1:3000}"
+ATTEMPTS=${WARMUP_ATTEMPTS:-3}
+PATHS=("/" "/about" "/studio")
+
+for path in "${PATHS[@]}"; do
+  for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    echo "Warming ${BASE_URL}${path} (attempt ${attempt}/${ATTEMPTS})"
+    curl -sSf -o /dev/null "${BASE_URL}${path}"
+    sleep 0.5
+  done
+  echo "Finished warming ${BASE_URL}${path}"
+  echo
+done


### PR DESCRIPTION
## Summary
- add a reusable warmup script to request the portfolio routes
- expose the warmup script via npm and run it from the Lighthouse CI workflow so requests happen after the server is online

## Testing
- npm run format
- npm run lint
- CI=1 npm run test
- npm run typecheck
- CI=1 npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d0668f1cc08322af8a29121352f376