### PR TITLE
Simplify ScrollCopy bridge cleanup

### DIFF
--- a/src/app/studio/components/ScrollCopy.tsx
+++ b/src/app/studio/components/ScrollCopy.tsx
@@ -39,27 +39,14 @@ const ScrollCopy: React.FC<Props> = ({
 
   const wordsQuery = '.sc-word';
 
-  const clearOverlays = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    el.querySelectorAll<HTMLSpanElement>('.sc-next').forEach((n) => n.remove());
-    el.querySelectorAll<HTMLSpanElement>(wordsQuery).forEach((w) => {
-      w.style.position = '';
-      (w as HTMLElement).style.visibility = '';
-      (w as HTMLElement).style.display = '';
-      (w as HTMLElement).style.width = '';
-      (w as HTMLElement).style.overflow = '';
-      w.classList.remove('sc-hide');
-      (w as HTMLElement).removeAttribute('data-sc-bridge-target');
-      (w as HTMLElement).removeAttribute('data-sc-bridge-source');
-    });
-  }, []);
-
   const buildParagraphBridges = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    clearOverlays();
+    el.querySelectorAll<HTMLSpanElement>(wordsQuery).forEach((span) => {
+      (span as HTMLElement).removeAttribute('data-sc-bridge-target');
+      (span as HTMLElement).removeAttribute('data-sc-bridge-source');
+    });
 
     const paras = Array.from(el.querySelectorAll<HTMLParagraphElement>('p'));
     paras.forEach((p, pIdx) => {
@@ -81,7 +68,7 @@ const ScrollCopy: React.FC<Props> = ({
         }
       }
     });
-  }, [clearOverlays]);
+  }, [wordsQuery]);
 
   const updateOpacity = useCallback(() => {
     rafRef.current = null;

--- a/src/components/layout/NavigationMenu/ThemeSelector.tsx
+++ b/src/components/layout/NavigationMenu/ThemeSelector.tsx
@@ -10,8 +10,8 @@ interface ThemeSelectorProps {
 }
 
 export default function ThemeSelector({ hidden = false }: ThemeSelectorProps) {
-  const { resolvedTheme, setTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
+  const theme = useTheme();
+  const isDark = theme.resolvedTheme === 'dark';
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
@@ -19,7 +19,7 @@ export default function ThemeSelector({ hidden = false }: ThemeSelectorProps) {
   }, []);
 
   const handleToggleTheme = () => {
-    setTheme(isDark ? 'light' : 'dark');
+    theme.setTheme(isDark ? 'light' : 'dark');
   };
 
   return (

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -11,3 +11,34 @@ declare module '@vercel/speed-insights/next' {
 
   export const SpeedInsights: ComponentType;
 }
+
+declare module 'next-themes' {
+  import type { ComponentType, ReactNode } from 'react';
+
+  export type Theme = string;
+
+  export interface ThemeProviderProps {
+    attribute?: string;
+    defaultTheme?: Theme;
+    enableSystem?: boolean;
+    storageKey?: string;
+    themes?: Theme[];
+    value?: Theme;
+    forcedTheme?: Theme;
+    enableColorScheme?: boolean;
+    children?: ReactNode;
+  }
+
+  export interface UseThemeProps {
+    themes: Theme[];
+    resolvedTheme?: Theme;
+    forcedTheme?: Theme;
+    systemTheme?: Theme;
+    setTheme(theme: Theme): void;
+    setForcedTheme?(theme?: Theme): void;
+  }
+
+  export const ThemeProvider: ComponentType<ThemeProviderProps>;
+
+  export function useTheme(): UseThemeProps;
+}


### PR DESCRIPTION
## Summary
- clear only the bridge metadata in `ScrollCopy` before rebuilding paragraph links
- provide local `next-themes` typings and update the theme selector to use the typed theme object

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d0856970e483229929d64842c3239d