### PR TITLE
refactor: centralize navigation links

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,7 @@
 import { buildPageMetadata } from '@/config/seo';
 
+import { navigationLinks } from '@/data';
+
 import Links from '../components/layout/NavigationMenu/Links';
 
 const title = '404 – Page not found';
@@ -21,13 +23,7 @@ export default function NotFound() {
       </p>
       <h2 className="text-lg">Here are some helpful links instead:</h2>
       <ul className="list-inside list-disc px-4 text-lg underline underline-offset-2">
-        <Links
-          links={[
-            { text: 'Home', href: '/' },
-            { text: 'Studio', href: '/studio' },
-            { text: 'About', href: '/about' },
-          ]}
-        />
+        <Links links={navigationLinks} />
       </ul>
       <p className="text-lg font-extrabold">Error code: 404</p>
     </section>

--- a/src/components/layout/NavigationMenu/Hamburger.tsx
+++ b/src/components/layout/NavigationMenu/Hamburger.tsx
@@ -5,6 +5,7 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 import { Menu, X } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
+import { navigationLinks } from '@/data';
 import cn from '@/utils';
 import Links from './Links';
 
@@ -133,14 +134,7 @@ export default function Hamburger({ isOpen, setIsOpen }: Props) {
             </button>
           </div>
 
-          <Links
-            isHamburguer
-            links={[
-              { text: 'Home', href: '/' },
-              { text: 'Studio', href: '/studio' },
-              { text: 'About', href: '/about' },
-            ]}
-          />
+          <Links isHamburguer links={navigationLinks} />
         </nav>
       )}
     </div>

--- a/src/components/layout/NavigationMenu/Links.tsx
+++ b/src/components/layout/NavigationMenu/Links.tsx
@@ -3,12 +3,14 @@
 import NextLink from 'next/link';
 import { usePathname } from 'next/navigation';
 
+import { navigationLinks, type NavigationLink } from '@/data';
+
 type Props = {
-  links: { href: `/${string}` | `https://${string}`; text: string }[];
+  links?: NavigationLink[];
   isHamburguer?: boolean;
 };
 
-const Links = ({ links, isHamburguer }: Props) => {
+const Links = ({ links = navigationLinks, isHamburguer }: Props) => {
   const pathname = `/${usePathname()?.split('/')[1] ?? ''}`;
   const isIndeterminate = links.every((l) => l.href !== pathname);
 

--- a/src/components/layout/NavigationMenu/index.tsx
+++ b/src/components/layout/NavigationMenu/index.tsx
@@ -4,10 +4,13 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
+import { navigationLinks } from '@/data';
 import cn from '@/utils';
 import Hamburger from './Hamburger';
 import Links from './Links';
 import ThemeSelector from './ThemeSelector';
+
+const desktopNavigationLinks = navigationLinks.filter(({ href }) => href !== '/');
 
 const NavigationMenu = () => {
   const [isHamburgerOpen, setIsHamburgerOpen] = useState(false);
@@ -36,12 +39,7 @@ const NavigationMenu = () => {
         </Link>
 
         <div className="flex flex-row-reverse items-center gap-3 sm:flex-row sm:gap-4">
-          <Links
-            links={[
-              { text: 'Studio', href: '/studio' },
-              { text: 'About', href: '/about' },
-            ]}
-          />
+          <Links links={desktopNavigationLinks} />
           <Hamburger isOpen={isHamburgerOpen} setIsOpen={setIsHamburgerOpen} />
           <ThemeSelector />
         </div>

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -5,6 +5,17 @@ export interface ContactLink {
   icon?: 'github' | 'linkedin' | 'email';
 }
 
+export type NavigationLink = {
+  text: string;
+  href: `/${string}` | `https://${string}` | `http://${string}`;
+};
+
+export const navigationLinks: NavigationLink[] = [
+  { text: 'Home', href: '/' },
+  { text: 'Studio', href: '/studio' },
+  { text: 'About', href: '/about' },
+];
+
 export const contactLinks: ContactLink[] = [
   {
     label: 'GitHub',


### PR DESCRIPTION
## Summary
- add a `NavigationLink` type and shared `navigationLinks` constants
- default `Links` to the shared navigation data and reuse it across navigation components
- pull 404 navigation suggestions from the shared links data

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test -- --runInBand
- CI=1 npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d084f6b7f883229e2508b9ae1bdb28