### PR TITLE
chore: remove unnecessary client directive

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,11 +1,10 @@
-﻿'use client';
-import React from 'react';
+import type { ReactNode } from 'react';
 
 import Background from './Background';
 import Footer from './Footer';
 import Header from './NavigationMenu';
 
-type Props = { children: React.ReactNode };
+type Props = { children: ReactNode };
 
 const Layout = (props: Props) => (
   <>


### PR DESCRIPTION
## Summary
- remove the client directive from the shared layout component now that it no longer needs client-only features
- switch the React import to a type-only import while keeping the component structure unchanged

## Testing
- npm run format
- npm run lint
- npm run test
- npm run typecheck
- CI=1 npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d0aec125948322899cd0e49f890e0f