### PR TITLE
chore: upgrade react 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10316,9 +10316,10 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
-                "@playwright/test": "^1.41.2",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
+                "@playwright/test": "^1.51.1",
+                "babel-plugin-react-compiler": "*",
+                "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
@@ -10326,6 +10327,9 @@
                     "optional": true
                 },
                 "@playwright/test": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
                     "optional": true
                 },
                 "sass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
                 "next": "15.5.3",
                 "next-seo": "^6.8.0",
                 "next-themes": "^0.4.6",
-                "react": "18.3.1",
-                "react-dom": "18.3.1",
+                "react": "19.1.1",
+                "react-dom": "19.1.1",
                 "tailwind-merge": "^3.3.1"
             },
             "devDependencies": {
@@ -27,8 +27,8 @@
                 "@testing-library/user-event": "^14.5.2",
                 "@types/jest": "^29.5.14",
                 "@types/node": "^24.5.2",
-                "@types/react": "^18.3.12",
-                "@types/react-dom": "^18.3.5",
+                "@types/react": "^19.1.13",
+                "@types/react-dom": "^19.1.9",
                 "autoprefixer": "^10.4.19",
                 "eslint": "9.36.0",
                 "eslint-plugin-react": "^7.37.1",
@@ -3563,32 +3563,24 @@
                 "undici-types": "~7.12.0"
             }
         },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.15",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/react": {
-            "version": "18.3.24",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-            "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+            "version": "19.1.13",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+            "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "version": "19.1.9",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+            "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^18.0.0"
+                "@types/react": "^19.0.0"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -9611,6 +9603,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -10043,6 +10036,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11150,28 +11144,24 @@
             "license": "MIT"
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+            "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
             "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+            "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
             "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.26.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^19.1.1"
             }
         },
         "node_modules/react-is": {
@@ -11401,13 +11391,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
         "next": "15.5.3",
         "next-seo": "^6.8.0",
         "next-themes": "^0.4.6",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
         "tailwind-merge": "^3.3.1"
     },
     "devDependencies": {
@@ -42,8 +42,8 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.5.2",
-        "@types/react": "^18.3.12",
-        "@types/react-dom": "^18.3.5",
+        "@types/react": "^19.1.13",
+        "@types/react-dom": "^19.1.9",
         "autoprefixer": "^10.4.19",
         "eslint": "9.36.0",
         "eslint-plugin-react": "^7.37.1",


### PR DESCRIPTION
## Summary
- bump react and react-dom to 19.1.1 together with the updated typings
- refresh package-lock.json to capture the React 19 dependency tree

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run vercel:build

------
https://chatgpt.com/codex/tasks/task_e_68d0b83c526883228c1e58d3df80838c