### PR TITLE
Refactor ScrollCopy opacity logic

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,3 +48,24 @@
   outline: 2px solid #3f3f46;
   outline-offset: 2px;
 }
+
+@layer components {
+  .scroll-copy {
+    --scroll-copy-base-opacity: 0.35;
+    --scroll-copy-max-opacity: 1;
+    --scroll-copy-word-gap: 0px;
+  }
+
+  .scroll-copy p {
+    word-spacing: var(--scroll-copy-word-gap);
+  }
+
+  .scroll-copy .sc-word {
+    opacity: var(--scroll-copy-base-opacity);
+    transition: opacity 200ms ease-out;
+  }
+
+  .scroll-copy .sc-word[data-sc-active='true'] {
+    opacity: var(--scroll-copy-max-opacity);
+  }
+}

--- a/src/app/studio/components/ScrollCopy.tsx
+++ b/src/app/studio/components/ScrollCopy.tsx
@@ -2,11 +2,7 @@
 
 import React, { CSSProperties, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 
-import {
-  calculateWordOpacities,
-  createBridges,
-  tokenize,
-} from './scrollCopyUtils';
+import { calculateWordOpacities, createBridges, tokenize } from './scrollCopyUtils';
 
 type Props = {
   className?: string; // container classes (e.g., space-y-8)
@@ -39,19 +35,16 @@ const ScrollCopy: React.FC<Props> = ({
 
   const wordsQuery = '.sc-word';
 
-  const scheduleOpacityUpdate = useCallback(
-    (callback: () => void) => {
-      if (rafRef.current != null) {
-        return;
-      }
+  const scheduleOpacityUpdate = useCallback((callback: () => void) => {
+    if (rafRef.current != null) {
+      return;
+    }
 
-      rafRef.current = requestAnimationFrame(() => {
-        rafRef.current = null;
-        callback();
-      });
-    },
-    []
-  );
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      callback();
+    });
+  }, []);
 
   const applyBridges = useCallback(() => {
     const el = containerRef.current;

--- a/src/app/studio/components/ScrollCopy.tsx
+++ b/src/app/studio/components/ScrollCopy.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { CSSProperties, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
+
+import {
+  calculateWordOpacities,
+  createBridges,
+  tokenize,
+} from './scrollCopyUtils';
 
 type Props = {
   className?: string; // container classes (e.g., space-y-8)
@@ -10,12 +16,6 @@ type Props = {
   thresholdRatioEnd?: number; // 0..1 of viewport height (e.g., 0.65)
   wordGap?: number; // px spacing between words
 };
-
-function tokenize(text: string): string[] {
-  // Split on whitespace, keep punctuation attached to words.
-  // Preserve spaces by appending a space to every token except last in paragraph when rendering.
-  return text.trim().split(/\s+/).filter(Boolean);
-}
 
 const CONTENT: string[] = [
   'Building digital products is hard.',
@@ -39,102 +39,103 @@ const ScrollCopy: React.FC<Props> = ({
 
   const wordsQuery = '.sc-word';
 
-  const buildParagraphBridges = useCallback(() => {
+  const scheduleOpacityUpdate = useCallback(
+    (callback: () => void) => {
+      if (rafRef.current != null) {
+        return;
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        callback();
+      });
+    },
+    []
+  );
+
+  const applyBridges = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    el.querySelectorAll<HTMLSpanElement>(wordsQuery).forEach((span) => {
-      (span as HTMLElement).removeAttribute('data-sc-bridge-target');
-      (span as HTMLElement).removeAttribute('data-sc-bridge-source');
+    const paragraphs = Array.from(el.querySelectorAll<HTMLParagraphElement>('p'));
+    const spansByParagraph = paragraphs.map((paragraph) =>
+      Array.from(paragraph.querySelectorAll<HTMLSpanElement>(wordsQuery))
+    );
+
+    const spans = spansByParagraph.flat();
+    spans.forEach((span) => {
+      delete span.dataset.scBridgeSource;
+      delete span.dataset.scBridgeTarget;
     });
 
-    const paras = Array.from(el.querySelectorAll<HTMLParagraphElement>('p'));
-    paras.forEach((p, pIdx) => {
-      const spans = Array.from(p.querySelectorAll<HTMLSpanElement>(wordsQuery));
-      if (spans.length === 0) return;
+    const bridgeMap = createBridges(
+      spansByParagraph.map((wordSpans) => wordSpans.map((span) => span.id))
+    );
 
-      // Bridge paragraph boundary: logically link last word of current paragraph to first word of next paragraph
-      const nextPara = paras[pIdx + 1];
-      if (nextPara) {
-        const nextFirst = nextPara.querySelector<HTMLSpanElement>(wordsQuery);
-        const lastSpan = spans[spans.length - 1];
-        if (nextFirst && lastSpan) {
-          // Ensure both have ids
-          if (!lastSpan.id) lastSpan.id = `scw-last-${pIdx}`;
-          if (!nextFirst.id) nextFirst.id = `scw-first-${pIdx + 1}`;
-          // Store a logical bridge between them for opacity control
-          (lastSpan as HTMLElement).setAttribute('data-sc-bridge-target', nextFirst.id);
-          (nextFirst as HTMLElement).setAttribute('data-sc-bridge-source', lastSpan.id);
-        }
-      }
+    const spanById = new Map(spans.map((span) => [span.id, span] as const));
+    bridgeMap.forEach(({ fromId, toId }) => {
+      const fromSpan = spanById.get(fromId);
+      const toSpan = spanById.get(toId);
+
+      if (!fromSpan || !toSpan) return;
+
+      fromSpan.dataset.scBridgeTarget = toId;
+      toSpan.dataset.scBridgeSource = fromId;
     });
   }, [wordsQuery]);
 
   const updateOpacity = useCallback(() => {
-    rafRef.current = null;
     const el = containerRef.current;
     if (!el) return;
 
-    const winH = window.innerHeight;
-    const base = baseOpacity;
-    const max = maxOpacity;
-
     const spans = Array.from(el.querySelectorAll<HTMLSpanElement>(wordsQuery));
-    const opMap = new Map<Element, number>();
-    const lastIndex = Math.max(1, spans.length - 1);
-    let activeIdx = -1;
-    spans.forEach((span, idx) => {
-      const r = span.getBoundingClientRect();
-      const c = r.top + r.height / 2;
-      const t = idx / lastIndex; // 0 for first, 1 for last
-      const ratio = thresholdRatioStart + t * (thresholdRatioEnd - thresholdRatioStart);
-      const cut = winH * ratio;
-      if (c <= cut) activeIdx = idx;
+    if (spans.length === 0) return;
+
+    const wordCenters = spans.map((span) => {
+      const rect = span.getBoundingClientRect();
+      return rect.top + rect.height / 2;
     });
 
-    spans.forEach((span, idx) => {
-      const opacity = idx <= activeIdx ? max : base;
-      opMap.set(span, opacity);
+    const opacities = calculateWordOpacities(wordCenters, window.innerHeight, {
+      baseOpacity,
+      maxOpacity,
+      thresholdRatioStart,
+      thresholdRatioEnd,
     });
 
-    const bridges: Array<{ from: HTMLSpanElement; to: HTMLSpanElement }> = [];
+    const spanById = new Map(spans.map((span) => [span.id, span] as const));
+    spans.forEach((span, index) => {
+      const opacity = opacities[index];
+      span.dataset.scActive = opacity === maxOpacity ? 'true' : 'false';
+    });
+
     spans.forEach((span) => {
-      const opacity = opMap.get(span) ?? base;
-      span.style.opacity = String(opacity);
-      // If this span bridges to next paragraph, force the next paragraph's first word
-      // to share the same opacity for a cohesive transition.
-      const targetId = (span as HTMLElement).dataset.scBridgeTarget;
-      if (targetId) {
-        const target = document.getElementById(targetId) as HTMLSpanElement | null;
-        if (target) bridges.push({ from: span, to: target });
-      }
-    });
+      const targetId = span.dataset.scBridgeTarget;
+      if (!targetId) return;
 
-    bridges.forEach(({ from, to }) => {
-      const opacity = opMap.get(from) ?? base;
-      to.style.opacity = String(opacity);
+      const target = spanById.get(targetId);
+      if (!target) return;
+
+      target.dataset.scActive = span.dataset.scActive;
     });
-  }, [baseOpacity, maxOpacity, thresholdRatioStart, thresholdRatioEnd]);
+  }, [baseOpacity, maxOpacity, thresholdRatioEnd, thresholdRatioStart, wordsQuery]);
 
   useLayoutEffect(() => {
-    // Build paragraph bridges after initial paint for accurate layout
-    buildParagraphBridges();
-    updateOpacity();
-    // Rebuild overlays on resize (line breaks change)
-    const onResize = () => {
-      buildParagraphBridges();
-      if (rafRef.current == null) {
-        rafRef.current = requestAnimationFrame(updateOpacity);
-      }
-    };
-    window.addEventListener('resize', onResize);
+    const runUpdate = () => updateOpacity();
 
-    // Update opacity on scroll
-    const onScroll = () => {
-      if (rafRef.current == null) {
-        rafRef.current = requestAnimationFrame(updateOpacity);
-      }
+    applyBridges();
+    runUpdate();
+
+    const onResize = () => {
+      applyBridges();
+      scheduleOpacityUpdate(runUpdate);
     };
+
+    const onScroll = () => {
+      scheduleOpacityUpdate(runUpdate);
+    };
+
+    window.addEventListener('resize', onResize);
     window.addEventListener('scroll', onScroll, { passive: true });
 
     return () => {
@@ -142,24 +143,37 @@ const ScrollCopy: React.FC<Props> = ({
       window.removeEventListener('scroll', onScroll);
       if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
     };
-  }, [buildParagraphBridges, updateOpacity]);
+  }, [applyBridges, scheduleOpacityUpdate, updateOpacity]);
 
-  // Rebuild when mounted (content is internal)
-  useEffect(() => {
-    buildParagraphBridges();
-    if (rafRef.current == null) rafRef.current = requestAnimationFrame(updateOpacity);
-  }, [buildParagraphBridges, updateOpacity]);
+  const styleVariables = useMemo(
+    () =>
+      ({
+        '--scroll-copy-base-opacity': baseOpacity,
+        '--scroll-copy-max-opacity': maxOpacity,
+        '--scroll-copy-word-gap': `${wordGap}px`,
+      }) as CSSProperties,
+    [baseOpacity, maxOpacity, wordGap]
+  );
 
   return (
-    <div ref={containerRef} className={className}>
-      {CONTENT.map((text, i) => {
+    <div
+      ref={containerRef}
+      className={['scroll-copy', className].filter(Boolean).join(' ')}
+      style={styleVariables}
+    >
+      {CONTENT.map((text, paragraphIndex) => {
         const tokens = tokenize(text);
         return (
-          <p key={i} style={{ wordSpacing: wordGap }}>
-            {tokens.map((tok, j) => (
-              <span id={`scw-${i}-${j}`} key={`${i}-${j}`} className="sc-word">
-                {tok}
-                {j < tokens.length - 1 ? ' ' : ''}
+          <p key={paragraphIndex}>
+            {tokens.map((token, wordIndex) => (
+              <span
+                id={`scw-${paragraphIndex}-${wordIndex}`}
+                key={`${paragraphIndex}-${wordIndex}`}
+                className="sc-word"
+                data-sc-active="false"
+              >
+                {token}
+                {wordIndex < tokens.length - 1 ? ' ' : ''}
               </span>
             ))}
           </p>

--- a/src/app/studio/components/scrollCopyUtils.ts
+++ b/src/app/studio/components/scrollCopyUtils.ts
@@ -1,0 +1,83 @@
+export type Bridge = {
+  fromId: string;
+  toId: string;
+};
+
+export type OpacityConfig = {
+  baseOpacity: number;
+  maxOpacity: number;
+  thresholdRatioStart: number;
+  thresholdRatioEnd: number;
+};
+
+/**
+ * Split a paragraph into tokens while preserving punctuation and spacing semantics.
+ */
+export function tokenize(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Create logical bridges between the last word of each paragraph and the first
+ * word of the following paragraph. The resulting structure is later used to
+ * keep opacities in sync across paragraph boundaries.
+ */
+export function createBridges(paragraphWordIds: string[][]): Bridge[] {
+  const bridges: Bridge[] = [];
+
+  for (let index = 0; index < paragraphWordIds.length; index += 1) {
+    const currentWords = paragraphWordIds[index];
+    if (currentWords.length === 0) {
+      continue;
+    }
+
+    let nextIndex = index + 1;
+    while (nextIndex < paragraphWordIds.length && paragraphWordIds[nextIndex].length === 0) {
+      nextIndex += 1;
+    }
+
+    if (nextIndex >= paragraphWordIds.length) {
+      continue;
+    }
+
+    const nextWords = paragraphWordIds[nextIndex];
+    bridges.push({
+      fromId: currentWords[currentWords.length - 1],
+      toId: nextWords[0],
+    });
+  }
+
+  return bridges;
+}
+
+/**
+ * Calculate the opacity assigned to each word based on its vertical position
+ * relative to the viewport and the configured thresholds.
+ */
+export function calculateWordOpacities(
+  wordCenters: number[],
+  viewportHeight: number,
+  config: OpacityConfig
+): number[] {
+  if (!wordCenters.length) {
+    return [];
+  }
+
+  const { baseOpacity, maxOpacity, thresholdRatioStart, thresholdRatioEnd } = config;
+
+  const lastIndex = Math.max(1, wordCenters.length - 1);
+  let activeIndex = -1;
+
+  wordCenters.forEach((centerY, index) => {
+    const interpolation = index / lastIndex;
+    const thresholdRatio =
+      thresholdRatioStart + interpolation * (thresholdRatioEnd - thresholdRatioStart);
+    const cutoff = viewportHeight * thresholdRatio;
+
+    if (centerY <= cutoff) {
+      activeIndex = index;
+    }
+  });
+
+  return wordCenters.map((_, index) => (index <= activeIndex ? maxOpacity : baseOpacity));
+}

--- a/tests/app/studio/ScrollCopy.test.tsx
+++ b/tests/app/studio/ScrollCopy.test.tsx
@@ -45,12 +45,7 @@ describe('scrollCopyUtils', () => {
   });
 
   it('creates bridges linking paragraph boundaries', () => {
-    const bridges = createBridges([
-      ['p0w0', 'p0w1'],
-      [],
-      ['p2w0', 'p2w1'],
-      ['p3w0'],
-    ]);
+    const bridges = createBridges([['p0w0', 'p0w1'], [], ['p2w0', 'p2w1'], ['p3w0']]);
 
     expect(bridges).toEqual([
       { fromId: 'p0w1', toId: 'p2w0' },

--- a/tests/app/studio/ScrollCopy.test.tsx
+++ b/tests/app/studio/ScrollCopy.test.tsx
@@ -1,6 +1,11 @@
 import { act, render } from '@testing-library/react';
 
 import ScrollCopy from '@/app/studio/components/ScrollCopy';
+import {
+  calculateWordOpacities,
+  createBridges,
+  tokenize,
+} from '@/app/studio/components/scrollCopyUtils';
 
 type FrameCallback = Parameters<typeof requestAnimationFrame>[0];
 
@@ -28,7 +33,46 @@ const setRect = (top: number): DOMRect => ({
   toJSON: () => ({}),
 });
 
-describe('ScrollCopy', () => {
+describe('scrollCopyUtils', () => {
+  it('tokenizes paragraphs into words preserving punctuation', () => {
+    expect(tokenize('Hello, world!  This is duonorth.')).toEqual([
+      'Hello,',
+      'world!',
+      'This',
+      'is',
+      'duonorth.',
+    ]);
+  });
+
+  it('creates bridges linking paragraph boundaries', () => {
+    const bridges = createBridges([
+      ['p0w0', 'p0w1'],
+      [],
+      ['p2w0', 'p2w1'],
+      ['p3w0'],
+    ]);
+
+    expect(bridges).toEqual([
+      { fromId: 'p0w1', toId: 'p2w0' },
+      { fromId: 'p2w1', toId: 'p3w0' },
+    ]);
+  });
+
+  it('calculates opacities based on word centers and thresholds', () => {
+    const centers = [100, 300, 900];
+    const viewportHeight = 1000;
+    const opacities = calculateWordOpacities(centers, viewportHeight, {
+      baseOpacity: 0.25,
+      maxOpacity: 0.85,
+      thresholdRatioStart: 0.2,
+      thresholdRatioEnd: 0.8,
+    });
+
+    expect(opacities).toEqual([0.85, 0.85, 0.25]);
+  });
+});
+
+describe('ScrollCopy component', () => {
   beforeEach(() => {
     rafQueue = [];
 
@@ -90,12 +134,8 @@ describe('ScrollCopy', () => {
     }
   });
 
-  it('builds paragraph bridges and keeps connected words in sync', () => {
+  it('builds paragraph bridges and synchronises active spans', () => {
     const { container } = render(<ScrollCopy baseOpacity={0.2} maxOpacity={0.8} />);
-
-    act(() => {
-      flushRaf();
-    });
 
     const paragraphs = container.querySelectorAll('p');
     const firstParagraph = paragraphs[0];
@@ -105,10 +145,8 @@ describe('ScrollCopy', () => {
     const lastWord = firstParagraphWords[firstParagraphWords.length - 1];
     const nextFirstWord = secondParagraph.querySelector<HTMLSpanElement>('.sc-word');
 
-    expect(lastWord).toBeTruthy();
-    expect(nextFirstWord).toBeTruthy();
-    expect(lastWord.dataset.scBridgeTarget).toBe(nextFirstWord?.id);
-    expect(nextFirstWord?.dataset.scBridgeSource).toBe(lastWord.id);
+    expect(lastWord?.dataset.scBridgeTarget).toBe(nextFirstWord?.id);
+    expect(nextFirstWord?.dataset.scBridgeSource).toBe(lastWord?.id);
 
     const allWords = Array.from(container.querySelectorAll<HTMLSpanElement>('.sc-word'));
     allWords.forEach((word) => {
@@ -126,11 +164,11 @@ describe('ScrollCopy', () => {
       flushRaf();
     });
 
-    expect(lastWord.style.opacity).toBe('0.8');
-    expect(nextFirstWord?.style.opacity).toBe('0.8');
+    expect(lastWord?.dataset.scActive).toBe('true');
+    expect(nextFirstWord?.dataset.scActive).toBe('true');
   });
 
-  it('applies custom opacity thresholds and spacing', () => {
+  it('applies custom opacity thresholds and spacing variables', () => {
     const { container } = render(
       <ScrollCopy
         baseOpacity={0.25}
@@ -141,13 +179,13 @@ describe('ScrollCopy', () => {
       />
     );
 
-    act(() => {
-      flushRaf();
-    });
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.getPropertyValue('--scroll-copy-base-opacity')).toBe('0.25');
+    expect(root.style.getPropertyValue('--scroll-copy-max-opacity')).toBe('0.95');
+    expect(root.style.getPropertyValue('--scroll-copy-word-gap')).toBe('4px');
 
     const words = Array.from(container.querySelectorAll<HTMLSpanElement>('.sc-word'));
-    const firstWord = words[0];
-    const secondWord = words[1];
+    const [firstWord, secondWord] = words;
 
     words.forEach((word, index) => {
       if (index === 0) {
@@ -162,10 +200,7 @@ describe('ScrollCopy', () => {
       flushRaf();
     });
 
-    expect(firstWord.style.opacity).toBe('0.95');
-    expect(secondWord.style.opacity).toBe('0.25');
-
-    const firstParagraph = container.querySelector('p');
-    expect(firstParagraph?.style.wordSpacing).toBe('4px');
+    expect(firstWord?.dataset.scActive).toBe('true');
+    expect(secondWord?.dataset.scActive).toBe('false');
   });
 });


### PR DESCRIPTION
## Summary
- extract pure helpers for tokenizing content, bridging paragraphs, and computing word opacities
- refactor the ScrollCopy component to rely on the new helpers and CSS custom properties instead of inline opacity styles
- add targeted ScrollCopy tests covering helper logic and scroll-driven behaviour with mocked requestAnimationFrame

## Testing
- npm run test -- ScrollCopy

------
https://chatgpt.com/codex/tasks/task_e_68de041f03548322941c4460ab113e02