### PR TITLE
Add coverage reporting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,25 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: 1
         run: npm ci
-      - name: Run CI verification
-        run: npm run ci
+      - name: Run format check
+        run: npm run format:check
+      - name: Run lint (CI)
+        run: npm run lint:ci
+      - name: Run typecheck
+        run: npm run typecheck
+      - name: Run tests (CI)
+        run: npm run test:ci
+      - name: Run production build
+        run: npm run build:prod
+      - name: Run coverage tests
+        run: npm run test:coverage
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "start": "next start",
         "test": "jest",
         "test:ci": "jest --ci",
+        "test:coverage": "jest --ci --coverage",
         "typecheck": "tsc --noEmit",
         "verify": "npm run format:check && npm run lint:ci && npm run typecheck && npm run test:ci && npm run build:prod",
         "ci": "npm run verify",


### PR DESCRIPTION
## Summary
- add a Jest coverage script to produce lcov output
- expand the CI workflow into discrete steps and upload coverage results to Codecov

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68df2b262afc8322a6c3950c149809dc