### PR TITLE
Ensure FinalCTA timeout is cleaned up

### DIFF
--- a/src/app/studio/components/FinalCTA.tsx
+++ b/src/app/studio/components/FinalCTA.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import StudioButton from './StudioButton';
 import cn from '@/utils';
@@ -10,6 +10,15 @@ const FinalCTA = () => {
   const email = 'hey@andremarinho.me';
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
 
   const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -24,8 +33,12 @@ const FinalCTA = () => {
         setCopied(true);
         if (timerRef.current) {
           window.clearTimeout(timerRef.current);
+          timerRef.current = null;
         }
-        timerRef.current = window.setTimeout(() => setCopied(false), 3600);
+        timerRef.current = window.setTimeout(() => {
+          setCopied(false);
+          timerRef.current = null;
+        }, 3600);
       })
       .catch(() => {
         setCopied(false);

--- a/src/app/studio/components/FinalCTA.tsx
+++ b/src/app/studio/components/FinalCTA.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import StudioButton from './StudioButton';
 import cn from '@/utils';
@@ -11,14 +11,18 @@ const FinalCTA = () => {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<number | null>(null);
 
+  const clearCopyTimeout = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     return () => {
-      if (timerRef.current) {
-        window.clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
+      clearCopyTimeout();
     };
-  }, []);
+  }, [clearCopyTimeout]);
 
   const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -31,10 +35,7 @@ const FinalCTA = () => {
       .writeText(email)
       .then(() => {
         setCopied(true);
-        if (timerRef.current) {
-          window.clearTimeout(timerRef.current);
-          timerRef.current = null;
-        }
+        clearCopyTimeout();
         timerRef.current = window.setTimeout(() => {
           setCopied(false);
           timerRef.current = null;


### PR DESCRIPTION
## Summary
- add an effect cleanup to clear the FinalCTA copy timeout when unmounting
- reset the copy timeout ref whenever it is cleared or completes

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1e34150dc8322a361a932aae8eb8f