### PR TITLE
Group Dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        dependency-type: 'production'
+      devDependencies:
+        dependency-type: 'development'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- group production dependencies into a Dependabot update group
- group development dependencies into a Dependabot update group

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45d4550288322ae34f22ab31c8991